### PR TITLE
Moved strings from codechecks to bundle.properties

### DIFF
--- a/jme3-code-check/src/com/jme3/gde/codecheck/hints/Bundle.properties
+++ b/jme3-code-check/src/com/jme3/gde/codecheck/hints/Bundle.properties
@@ -6,3 +6,7 @@ TempVarsHint.display-name=TempVars might not be released
 TempVarsHint.id=TempVars release check
 TempVarsHint.description=Checks for calls TempVars.get() and search for correspondinng release() call
 TempVarsHint.fix-text=Add a release() call at the end of the method
+ReadOnlyPrimitiveHint.display-name=This primitive is read only and should not be modified!
+ReadOnlyPrimitiveHint.id=ReadOnly Primitives
+ReadOnlyPrimitiveHint.description=Checks for modifications to readonly primitives. (getLocalTranslation().set())
+ReadOnlyPrimitiveHint.fix-text=Remove this call

--- a/jme3-code-check/src/com/jme3/gde/codecheck/hints/Bundle.properties
+++ b/jme3-code-check/src/com/jme3/gde/codecheck/hints/Bundle.properties
@@ -2,3 +2,7 @@ UpdateHint.display-name=Updating is not needed in jME3, check your update order 
 UpdateHint.id=Update States / Bound
 UpdateHint.description=Checks for calls to updateGeometricState(), updateLogicalState() and updateModelBound().
 UpdateHint.fix-text=Remove this call
+TempVarsHint.display-name=TempVars might not be released
+TempVarsHint.id=TempVars release check
+TempVarsHint.description=Checks for calls TempVars.get() and search for correspondinng release() call
+TempVarsHint.fix-text=Add a release() call at the end of the method

--- a/jme3-code-check/src/com/jme3/gde/codecheck/hints/Bundle.properties
+++ b/jme3-code-check/src/com/jme3/gde/codecheck/hints/Bundle.properties
@@ -1,0 +1,4 @@
+UpdateHint.display-name=Updating is not needed in jME3, check your update order if you need to call this.
+UpdateHint.id=Update States / Bound
+UpdateHint.description=Checks for calls to updateGeometricState(), updateLogicalState() and updateModelBound().
+UpdateHint.fix-text=Remove this call

--- a/jme3-code-check/src/com/jme3/gde/codecheck/hints/Bundle.properties
+++ b/jme3-code-check/src/com/jme3/gde/codecheck/hints/Bundle.properties
@@ -10,3 +10,7 @@ ReadOnlyPrimitiveHint.display-name=This primitive is read only and should not be
 ReadOnlyPrimitiveHint.id=ReadOnly Primitives
 ReadOnlyPrimitiveHint.description=Checks for modifications to readonly primitives. (getLocalTranslation().set())
 ReadOnlyPrimitiveHint.fix-text=Remove this call
+InternalMethodHint.display-name=You should not call this method, its for internal use only!
+InternalMethodHint.id=Internal Methods
+InternalMethodHint.description=Checks for calls to internal methods.
+InternalMethodHint.fix-text=Remove this call

--- a/jme3-code-check/src/com/jme3/gde/codecheck/hints/InternalMethodHint.java
+++ b/jme3-code-check/src/com/jme3/gde/codecheck/hints/InternalMethodHint.java
@@ -22,6 +22,7 @@ import org.netbeans.spi.editor.hints.ErrorDescription;
 import org.netbeans.spi.editor.hints.ErrorDescriptionFactory;
 import org.netbeans.spi.editor.hints.Fix;
 import org.openide.awt.StatusDisplayer;
+import org.openide.util.NbBundle;
 
 public class InternalMethodHint extends AbstractHint {
 
@@ -84,19 +85,19 @@ public class InternalMethodHint extends AbstractHint {
     //Message that the user sees in the left sidebar:
     @Override
     public String getDisplayName() {
-        return "You should not call this method, its for internal use only!";
+        return NbBundle.getMessage(InternalMethodHint.class, "InternalMethodHint.display-name");
     }
 
     //Name of the hint in the Options window:
     @Override
     public String getId() {
-        return "Internal Methods";
+        return NbBundle.getMessage(InternalMethodHint.class, "InternalMethodHint.id");
     }
 
     //Description of the hint in the Options window:
     @Override
     public String getDescription() {
-        return "Checks for calls to internal methods.";
+        return NbBundle.getMessage(InternalMethodHint.class, "InternalMethodHint.description");
     }
 
     class MessagesFix implements EnhancedFix {
@@ -118,7 +119,7 @@ public class InternalMethodHint extends AbstractHint {
 
         @Override
         public String getText() {
-            return "Remove this call";
+            return NbBundle.getMessage(InternalMethodHint.class, "InternalMethodHint.fix-text");
         }
 
         @Override

--- a/jme3-code-check/src/com/jme3/gde/codecheck/hints/ReadOnlyPrimitiveHint.java
+++ b/jme3-code-check/src/com/jme3/gde/codecheck/hints/ReadOnlyPrimitiveHint.java
@@ -21,6 +21,7 @@ import org.netbeans.spi.editor.hints.ErrorDescription;
 import org.netbeans.spi.editor.hints.ErrorDescriptionFactory;
 import org.netbeans.spi.editor.hints.Fix;
 import org.openide.awt.StatusDisplayer;
+import org.openide.util.NbBundle;
 
 public class ReadOnlyPrimitiveHint extends AbstractHint {
 
@@ -94,19 +95,19 @@ public class ReadOnlyPrimitiveHint extends AbstractHint {
     //Message that the user sees in the left sidebar:
     @Override
     public String getDisplayName() {
-        return "This primitive is read only and should not be modified!";
+        return NbBundle.getMessage(ReadOnlyPrimitiveHint.class, "ReadOnlyPrimitiveHint.display-name");
     }
 
     //Name of the hint in the Options window:
     @Override
     public String getId() {
-        return "ReadOnly Primitives";
+        return NbBundle.getMessage(ReadOnlyPrimitiveHint.class, "ReadOnlyPrimitiveHint.id");
     }
 
     //Description of the hint in the Options window:
     @Override
     public String getDescription() {
-        return "Checks for modifications to readonly primitives. (getLocalTranslation().set())";
+        return NbBundle.getMessage(ReadOnlyPrimitiveHint.class, "ReadOnlyPrimitiveHint.description");
     }
 
     class MessagesFix implements EnhancedFix {
@@ -128,7 +129,7 @@ public class ReadOnlyPrimitiveHint extends AbstractHint {
 
         @Override
         public String getText() {
-            return "Remove this call";
+            return NbBundle.getMessage(ReadOnlyPrimitiveHint.class, "ReadOnlyPrimitiveHint.fix-text");
         }
 
         @Override

--- a/jme3-code-check/src/com/jme3/gde/codecheck/hints/TempVarsHint.java
+++ b/jme3-code-check/src/com/jme3/gde/codecheck/hints/TempVarsHint.java
@@ -24,6 +24,7 @@ import org.netbeans.spi.editor.hints.ErrorDescription;
 import org.netbeans.spi.editor.hints.ErrorDescriptionFactory;
 import org.netbeans.spi.editor.hints.Fix;
 import org.openide.awt.StatusDisplayer;
+import org.openide.util.NbBundle;
 
 public class TempVarsHint extends AbstractHint {
 
@@ -135,19 +136,19 @@ public class TempVarsHint extends AbstractHint {
     //Message that the user sees in the left sidebar:
     @Override
     public String getDisplayName() {
-        return "TempVars might not be released";
+        return NbBundle.getMessage(TempVarsHint.class, "TempVarsHint.display-name");
     }
 
     //Name of the hint in the Options window:
     @Override
     public String getId() {
-        return "TempVars release check";
+        return NbBundle.getMessage(TempVarsHint.class, "TempVarsHint.id");
     }
 
     //Description of the hint in the Options window:
     @Override
     public String getDescription() {
-        return "Checks for calls TempVars.get() and search for correspondinng release() call";
+        return NbBundle.getMessage(TempVarsHint.class, "TempVarsHint.description");
     }
 
     class MessagesFix implements EnhancedFix {
@@ -169,7 +170,7 @@ public class TempVarsHint extends AbstractHint {
 
         @Override
         public String getText() {
-            return "Add a release() call at the end of the method";
+            return NbBundle.getMessage(TempVarsHint.class, "TempVarsHint.fix-text");
         }
 
         @Override

--- a/jme3-code-check/src/com/jme3/gde/codecheck/hints/UpdateHint.java
+++ b/jme3-code-check/src/com/jme3/gde/codecheck/hints/UpdateHint.java
@@ -21,6 +21,7 @@ import org.netbeans.spi.editor.hints.ErrorDescription;
 import org.netbeans.spi.editor.hints.ErrorDescriptionFactory;
 import org.netbeans.spi.editor.hints.Fix;
 import org.openide.awt.StatusDisplayer;
+import org.openide.util.NbBundle;
 
 public class UpdateHint extends AbstractHint {
 
@@ -86,19 +87,22 @@ public class UpdateHint extends AbstractHint {
     //Message that the user sees in the left sidebar:
     @Override
     public String getDisplayName() {
-        return "Updating is not needed in jME3, check your update order if you need to call this.";
+        //return "Updating is not needed in jME3, check your update order if you need to call this.";
+        return NbBundle.getMessage(UpdateHint.class, "UpdateHint.display-name");
     }
 
     //Name of the hint in the Options window:
     @Override
     public String getId() {
-        return "Update States / Bound";
+        //return "Update States / Bound";
+        return NbBundle.getMessage(UpdateHint.class, "UpdateHint.id");
     }
 
     //Description of the hint in the Options window:
     @Override
     public String getDescription() {
-        return "Checks for calls to updateGeometricState(), updateLogicalState() and updateModelBound().";
+        //return "Checks for calls to updateGeometricState(), updateLogicalState() and updateModelBound().";
+        return NbBundle.getMessage(UpdateHint.class, "UpdateHint.description");
     }
 
     class MessagesFix implements EnhancedFix {
@@ -120,7 +124,8 @@ public class UpdateHint extends AbstractHint {
 
         @Override
         public String getText() {
-            return "Remove this call";
+            //return "Remove this call";
+            return NbBundle.getMessage(UpdateHint.class, "UpdateHint.fix-text");
         }
 
         @Override

--- a/jme3-code-check/src/com/jme3/gde/codecheck/hints/UpdateHint.java
+++ b/jme3-code-check/src/com/jme3/gde/codecheck/hints/UpdateHint.java
@@ -87,21 +87,18 @@ public class UpdateHint extends AbstractHint {
     //Message that the user sees in the left sidebar:
     @Override
     public String getDisplayName() {
-        //return "Updating is not needed in jME3, check your update order if you need to call this.";
         return NbBundle.getMessage(UpdateHint.class, "UpdateHint.display-name");
     }
 
     //Name of the hint in the Options window:
     @Override
     public String getId() {
-        //return "Update States / Bound";
         return NbBundle.getMessage(UpdateHint.class, "UpdateHint.id");
     }
 
     //Description of the hint in the Options window:
     @Override
     public String getDescription() {
-        //return "Checks for calls to updateGeometricState(), updateLogicalState() and updateModelBound().";
         return NbBundle.getMessage(UpdateHint.class, "UpdateHint.description");
     }
 
@@ -124,7 +121,6 @@ public class UpdateHint extends AbstractHint {
 
         @Override
         public String getText() {
-            //return "Remove this call";
             return NbBundle.getMessage(UpdateHint.class, "UpdateHint.fix-text");
         }
 


### PR DESCRIPTION
Moved strings from codechecks to a separate bundle as a part of preparation for a larger refactor of codechecks package.