### PR TITLE
Updated Bloom filter wizard's name

### DIFF
--- a/jme3-core/src/com/jme3/gde/core/filters/impl/NewBloomFilterAction.java
+++ b/jme3-core/src/com/jme3/gde/core/filters/impl/NewBloomFilterAction.java
@@ -62,7 +62,7 @@ public class NewBloomFilterAction extends AbstractNewFilterWizardAction {
         WizardDescriptor wizardDescriptor = new WizardDescriptor(getPanels());
         // {0} will be replaced by WizardDesriptor.Panel.getComponent().getName()
         wizardDescriptor.setTitleFormat(new MessageFormat("{0}"));
-        wizardDescriptor.setTitle("Your wizard dialog title here");
+        wizardDescriptor.setTitle("New Bloom Filter Wizard");
         Dialog dialog = DialogDisplayer.getDefault().createDialog(wizardDescriptor);
         dialog.setVisible(true);
         dialog.toFront();


### PR DESCRIPTION
Also the Bloom Filter Wizard does not support `SceneAndObjects` GlowMode. I was looking into how to fix it and figured out that it would require adding another JLabel into the menu and another `else if` into the `doCreateFilter()` function of `NewBloomFilterAction`. If no one fixes that I can maybe do it later.