### PR TITLE
jbullet lib lacks jbullet.jar: use native bullet in JmeTests template

### DIFF
--- a/JME3TestsTemplate/nbproject/project.properties
+++ b/JME3TestsTemplate/nbproject/project.properties
@@ -35,7 +35,8 @@ javac.classpath=\
     ${libs.jme3-niftygui.classpath}:\
     ${libs.jme3-effects.classpath}:\
     ${libs.jme3-terrain.classpath}:\
-    ${libs.jme3-jbullet.classpath}:\
+    ${libs.jme3-bullet.classpath}:\
+    ${libs.jme3-bullet-native.classpath}:\
     ${libs.jme3-test-data.classpath}
 # Space-separated list of extra javac options
 javac.compilerargs=


### PR DESCRIPTION
My proposed fix for Issue #119 (JmeTests should specify native bullet, not jBullet). I haven't checked to see if the Android version of JmeTests has the same issue.