### PR TITLE
Fix LightProbe scaling by pressing S not working on jme version > 3.2

### DIFF
--- a/jme3-scenecomposer/src/com/jme3/gde/scenecomposer/gizmo/light/LightProbeGizmo.java
+++ b/jme3-scenecomposer/src/com/jme3/gde/scenecomposer/gizmo/light/LightProbeGizmo.java
@@ -92,7 +92,7 @@ public class LightProbeGizmo extends NodeCallback {
      */
     @Override
     public void onResize(Vector3f oldScale, Vector3f newScale) {
-        ((BoundingSphere)jmeProbe.getLightProbe().getBounds()).setRadius(LightGizmoFactory.scaleToRadius(newScale));
+        jmeProbe.getLightProbe().getArea().setRadius(LightGizmoFactory.scaleToRadius(newScale));
     }
 
     /**


### PR DESCRIPTION
Setting the radius directly in the properties window on the right is still broken and doesn't work at all.