### PR TITLE
Version bump and build_engine.sh fixes for existing installs

### DIFF
--- a/build_engine.sh
+++ b/build_engine.sh
@@ -2,14 +2,20 @@
 # This Shell Script will build and use the latest jMonkeyEngine git version, so there might be some undiscovered engine bugs, watch out!
 # Also if you want to revert to releases and bintray builds, you need to uninstall them from your local maven repo...
 
-echo "Downloading the Engine, this may take some time"
-if [ "x$TRAVIS" != "x" ] && [ "x$TRAVIS_TAG" != "x" ]; then
-    # Extract the engine version from the sdk branch tag.
-    git clone -b $(echo "$TRAVIS_TAG" | sed -n 's/\(v.\+\)-sdk.\+/\1/p') --single-branch --depth 10 https://github.com/jMonkeyEngine/jMonkeyEngine/ engine # single-branch requires git > 1.7.10, if you see an error, just leave it out.
+if [ ! -d "engine" ]; then
+    echo "Downloading the Engine, this may take some time"
+    if [ "x$TRAVIS" != "x" ] && [ "x$TRAVIS_TAG" != "x" ]; then
+        # Extract the engine version from the sdk branch tag.
+        git clone -b $(echo "$TRAVIS_TAG" | sed -n 's/\(v.\+\)-sdk.\+/\1/p') --single-branch --depth 10 https://github.com/jMonkeyEngine/jMonkeyEngine/ engine # single-branch requires git > 1.7.10, if you see an error, just leave it out.
+    else
+        git clone -b master --single-branch --depth 10 https://github.com/jMonkeyEngine/jMonkeyEngine/ engine # single-branch requires git > 1.7.10, if you see an error, just leave it out.
+    fi
+    cd engine
 else
-    git clone -b master --single-branch --depth 10 https://github.com/jMonkeyEngine/jMonkeyEngine/ engine # single-branch requires git > 1.7.10, if you see an error, just leave it out.
+    echo "Engine already cloned, pulling updates."
+    cd engine
+    git pull
 fi
-cd engine
 # git checkout tags/v3.1.0-beta2 # To use this, leave out depth and change -b to a branch.
 
 #echo "Patching the Engine...."

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 # Version number used for plugins, only 3 numbers (e.g. 3.1.3)
-jmeVersion = 3.2.0
+jmeVersion = 3.3.0
 # Version used for application and settings folder, no spaces!
-jmeMainVersion = 3.2
+jmeMainVersion = 3.3
 # Version addition pre-alpha-svn, Stable, Beta
 #jmeVersionTag = SNAPSHOT
 # Increment this each time jmeVersionTag changes but jmeVersion stays the same


### PR DESCRIPTION
Updated the display version of the sdk to 3.3 and added a git pull to build_engine.sh in case the engine/ folder is already present. 