### PR TITLE
Remove readonly flag so cleaner.exe can delete

### DIFF
--- a/jdks/download-jdks.sh
+++ b/jdks/download-jdks.sh
@@ -143,6 +143,8 @@ function unpack_windows {
     #unzip -qq tools.zip -d .
     #rm tools.zip
 
+    find . -exec chmod u+w {} \; # Make all file writable to allow uninstaller's cleaner to remove file    
+    
     find . -type f \( -name "*.exe" -o -name "*.dll" \) -exec chmod u+rwx {} \; # Make them executable
 
     find . -type f -name "*.pack" | while read eachFile; do


### PR DESCRIPTION
If JDK files do not have write permission the Windows uninstaller will not be able to delete the files.

See https://lists.apache.org/thread.html/1f22c459e24479f297dd2139651cf1b7cabc3ee8fa9e238423f5b5df@%3Cdev.netbeans.apache.org%3E