### PR TITLE
iOS: add ProGuard exclusions

### DIFF
--- a/jme3-ios/ios-data/templates/ios.properties
+++ b/jme3-ios/ios-data/templates/ios.properties
@@ -48,7 +48,17 @@ ios.proguard.options=-keep public class com.jme3.system.ios.*{public *;} \
 -keep public class * implements javax.xml.parsers.SAXParserFactory{public *;} \
 -keep public class com.sun.org.apache.xerces.internal.jaxp.SAXParserFactoryImpl \
 -keep public class com.sun.org.apache.xerces.internal.impl.dv.dtd.DTDDVFactoryImpl \
--keep public class sun.nio.fs.MacOSXFileSystemProvider
+-keep public class sun.nio.fs.MacOSXFileSystemProvider \
+-keep public class * extends java.nio.charset.Charset { *; } \
+-keep public class java.util.zip.Deflater { *; } \
+-keep public class java.io.FileNotFoundException { *; } \
+-keep public class java.lang.reflect.Proxy { *; } \
+-keep public class java.lang.reflect.InvocationHandler { *; } \
+-keep public class java.util.logging.ConsoleHandler \
+-keep public class java.util.logging.FileHandler \
+-keep public class java.util.logging.SimpleFormatter \
+-keep public class java.util.logging.LogManager { *; } \
+-keep public class org.xmlpull.mxp1.MXParserFactory { *; }
 
 # native compile
 ios.cc.source.dir=ios/src
@@ -57,7 +67,7 @@ ios.cc.compiler=clang
 ios.cc.cflags=-D__IPHONE_OS_VERSION_MIN_REQUIRED=30202 \
 -fobjc-abi-version=2 -fobjc-legacy-dispatch \
 -I/System/Library/Frameworks/JavaVM.framework/Headers \
--I/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.9.sdk/System/Library/Frameworks/JavaVM.framework/Headers/
+-I/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/JavaVM.framework/Headers/
 
 # arm/i386 section, resolved in build file to ios.avian.bootimage-generator etc.
 ios.avian.path.arm=${ios.avian.path}/avian-arm


### PR DESCRIPTION
1. Exclusions:
java.nio.charset.Charset:
Otherwise you are limited to UTF-8 (and for example cannot use java.util.zip, because it uses ISO-8859-1)

For java.util.zip.Deflater:
java.util.zip.Deflater
java.io.FileNotFoundException

For reflection (IIRC nifty-gui and Java Annotations)
java.lang.reflect.Proxy
java.lang.reflect.InvocationHandler

For logging:
java.util.logging.ConsoleHandler
java.util.logging.FileHandler
java.util.logging.SimpleFormatter
java.util.logging.LogManager

For nifty-gui:
org.xmlpull.mxp1.MXParserFactory

2. Removed iOS version: just use link to the most recent version
This should reduce failing builds with new projects significantly!