### PR TITLE
Enable Gradle support by default

### DIFF
--- a/nbproject/platform.properties
+++ b/nbproject/platform.properties
@@ -3,6 +3,7 @@ keystore=../nbproject/private/keystore
 nbm_alias=jmeupdates
 cluster.path=\
     ${nbplatform.active.dir}/extide:\
+    ${nbplatform.active.dir}/groovy:\
     ${nbplatform.active.dir}/harness:\
     ${nbplatform.active.dir}/ide:\
     ${nbplatform.active.dir}/java:\
@@ -56,6 +57,12 @@ disabled.modules=\
     org.netbeans.modules.form.kit,\
     org.netbeans.modules.form.nb,\
     org.netbeans.modules.form.refactoring,\
+    org.netbeans.modules.gradle.htmlui,\
+    org.netbeans.modules.gradle.javaee,\
+    org.netbeans.modules.gradle.persistence,\
+    org.netbeans.modules.gradle.spring,\
+    org.netbeans.modules.gradle.test,\
+    org.netbeans.modules.groovy.and.gradle.kit,\
     org.netbeans.modules.hudson,\
     org.netbeans.modules.hudson.ant,\
     org.netbeans.modules.hudson.git,\
@@ -81,17 +88,13 @@ disabled.modules=\
     org.netbeans.modules.jemmy,\
     org.netbeans.modules.languages,\
     org.netbeans.modules.localtasks,\
-    org.netbeans.modules.maven,\
     org.netbeans.modules.maven.checkstyle,\
     org.netbeans.modules.maven.coverage,\
-    org.netbeans.modules.maven.embedder,\
     org.netbeans.modules.maven.grammar,\
     org.netbeans.modules.maven.graph,\
     org.netbeans.modules.maven.hints,\
-    org.netbeans.modules.maven.indexer,\
     org.netbeans.modules.maven.junit,\
     org.netbeans.modules.maven.kit,\
-    org.netbeans.modules.maven.model,\
     org.netbeans.modules.maven.osgi,\
     org.netbeans.modules.maven.persistence,\
     org.netbeans.modules.maven.refactoring,\


### PR DESCRIPTION
Adds Gradle support by default. Also adds support for Maven, I guess that is alright. This is like the minimum amount of stuff brought in with the Gradle.

Next up could be implementing the #255 template. But at least this is a nice addition on its own.