### PR TITLE
Fix Gradle dependency to work with Netbeans 12

### DIFF
--- a/jme3-core/nbproject/project.xml
+++ b/jme3-core/nbproject/project.xml
@@ -160,8 +160,8 @@
                     <build-prerequisite/>
                     <compile-dependency/>
                     <run-dependency>
-                        <release-version>1</release-version>
-                        <specification-version>1.5</specification-version>
+                        <release-version>2</release-version>
+                        <specification-version>2.0</specification-version>
                     </run-dependency>
                 </dependency>
                 <dependency>
@@ -169,7 +169,7 @@
                     <build-prerequisite/>
                     <compile-dependency/>
                     <run-dependency>
-                        <specification-version>1.5</specification-version>
+                        <specification-version>1.6</specification-version>
                     </run-dependency>
                 </dependency>
                 <dependency>


### PR DESCRIPTION
I could not build against the NB 12 without updating the Gradle lib dependencies, so here we go