### PR TITLE
Projectfactory

### DIFF
--- a/jme3-assetpack-support/src/META-INF/services/org.netbeans.spi.project.ProjectFactory
+++ b/jme3-assetpack-support/src/META-INF/services/org.netbeans.spi.project.ProjectFactory
@@ -1,1 +1,0 @@
-com.jme3.gde.assetpack.project.AssetPackProjectFactory

--- a/jme3-assetpack-support/src/com/jme3/gde/assetpack/project/AssetPackProject.java
+++ b/jme3-assetpack-support/src/com/jme3/gde/assetpack/project/AssetPackProject.java
@@ -22,8 +22,8 @@ import javax.swing.JPanel;
 import org.netbeans.api.project.Project;
 import org.netbeans.api.project.ProjectInformation;
 import org.netbeans.spi.project.ActionProvider;
-import org.netbeans.spi.project.DeleteOperationImplementation;
 import org.netbeans.spi.project.CopyOperationImplementation;
+import org.netbeans.spi.project.DeleteOperationImplementation;
 import org.netbeans.spi.project.ProjectState;
 import org.netbeans.spi.project.ui.CustomizerProvider;
 import org.netbeans.spi.project.ui.LogicalViewProvider;
@@ -45,14 +45,16 @@ import org.xml.sax.InputSource;
 @SuppressWarnings("unchecked")
 public class AssetPackProject implements Project {
 
+    public static final ImageIcon assetPackIcon = ImageUtilities.loadImageIcon("com/jme3/gde/assetpack/icons/assetpack.png", false);
+
     private final FileObject projectDir;
-    private LogicalViewProvider logicalView = new AssetPackProjectLogicalView(this);
-    private String assetsFolder = "assets";
+    private final LogicalViewProvider logicalView = new AssetPackProjectLogicalView(this);
+    private final String assetsFolder = "assets";
     private final ProjectState state;
     private Lookup lkp;
-    private ProjectAssetManager projectAssetManager;
+    private final ProjectAssetManager projectAssetManager;
     private Document configuration;
-    private AssetPackProjectCustomizer projectCustomizer;
+    private final AssetPackProjectCustomizer projectCustomizer;
     private AssetPackBrowserFolder assetPackFolder;
 
     public AssetPackProject(FileObject projectDir, ProjectState state) {
@@ -247,7 +249,7 @@ public class AssetPackProject implements Project {
 //    }
     private final class ActionProviderImpl implements ActionProvider {
 
-        private String[] supported = new String[]{
+        private final String[] supported = new String[]{
             ActionProvider.COMMAND_DELETE,
             ActionProvider.COMMAND_COPY,};
 
@@ -280,19 +282,23 @@ public class AssetPackProject implements Project {
 
     private final class DemoDeleteOperation implements DeleteOperationImplementation {
 
+        @Override
         public void notifyDeleting() throws IOException {
         }
 
+        @Override
         public void notifyDeleted() throws IOException {
         }
 
+        @Override
         public List<FileObject> getMetadataFiles() {
-            List<FileObject> dataFiles = new ArrayList<FileObject>();
+            List<FileObject> dataFiles = new ArrayList<>();
             return dataFiles;
         }
 
+        @Override
         public List<FileObject> getDataFiles() {
-            List<FileObject> dataFiles = new ArrayList<FileObject>();
+            List<FileObject> dataFiles = new ArrayList<>();
             return dataFiles;
         }
     }
@@ -307,24 +313,28 @@ public class AssetPackProject implements Project {
             this.projectDir = project.getProjectDirectory();
         }
 
+        @Override
         public List<FileObject> getMetadataFiles() {
-            return Collections.EMPTY_LIST;
+            return Collections.emptyList();
         }
 
+        @Override
         public List<FileObject> getDataFiles() {
-            return Collections.EMPTY_LIST;
+            return Collections.emptyList();
         }
 
+        @Override
         public void notifyCopying() throws IOException {
         }
 
+        @Override
         public void notifyCopied(Project arg0, File arg1, String arg2) throws IOException {
         }
     }
 
     private final class AssetPackProjectCustomizer implements CustomizerProvider, ProjectCustomizer.CategoryComponentProvider, ActionListener {
 
-        private Category[] propertyCategories = new Category[]{
+        private final Category[] propertyCategories = new Category[]{
             Category.create("General", "General", null),
             Category.create("License", "License", null),};
         AssetPackProject project;
@@ -335,10 +345,12 @@ public class AssetPackProject implements Project {
             this.project = project;
         }
 
+        @Override
         public void showCustomizer() {
             ProjectCustomizer.createCustomizerDialog(propertyCategories, this, "General", this, new HelpCtx("sdk.asset_packs")).setVisible(true);
         }
 
+        @Override
         public JComponent create(Category category) {
             if (category.getName().equals("General")) {
                 panel1 =
@@ -354,6 +366,7 @@ public class AssetPackProject implements Project {
 
         }
 
+        @Override
         public void actionPerformed(ActionEvent e) {
             panel1.actionPerformed(null);
             panel2.actionPerformed(null);
@@ -366,8 +379,7 @@ public class AssetPackProject implements Project {
 
         @Override
         public Icon getIcon() {
-            return new ImageIcon(ImageUtilities.loadImage(
-                    "com/jme3/gde/assetpack/icons/assetpack.png"));
+            return assetPackIcon;
         }
 
         @Override

--- a/jme3-assetpack-support/src/com/jme3/gde/assetpack/project/AssetPackProjectFactory.java
+++ b/jme3-assetpack-support/src/com/jme3/gde/assetpack/project/AssetPackProjectFactory.java
@@ -2,21 +2,22 @@ package com.jme3.gde.assetpack.project;
 
 import java.io.IOException;
 import org.netbeans.api.project.Project;
+import org.netbeans.api.project.ProjectManager;
 import org.netbeans.spi.project.ProjectFactory;
+import org.netbeans.spi.project.ProjectFactory2;
 import org.netbeans.spi.project.ProjectState;
 import org.openide.filesystems.FileObject;
+import org.openide.util.lookup.ServiceProvider;
 
-public class AssetPackProjectFactory implements ProjectFactory {
+@ServiceProvider(service = ProjectFactory.class)
+public class AssetPackProjectFactory implements ProjectFactory2 {
 
     public static final String CONFIG_NAME = "assetpack.xml";
 
     //Specifies when a project is a project, i.e. properties file exists
     @Override
     public boolean isProject(FileObject projectDirectory) {
-        if (projectDirectory.getFileObject(CONFIG_NAME) != null) {
-            return true;
-        }
-        return false;
+        return projectDirectory.getFileObject(CONFIG_NAME) != null;
     }
 
     //Specifies when the project will be opened, i.e.,
@@ -35,5 +36,14 @@ public class AssetPackProjectFactory implements ProjectFactory {
                     + " cannot save project");
         }
         ((AssetPackProject)project).saveSettings();
+    }
+
+    @Override
+    public ProjectManager.Result isProject2(FileObject fo) {
+        if (!isProject(fo)) {
+            return null;
+        }
+
+        return new ProjectManager.Result(AssetPackProject.assetPackIcon);
     }
 }

--- a/jme3-assetpack-support/src/com/jme3/gde/assetpack/project/AssetPackProjectLogicalView.java
+++ b/jme3-assetpack-support/src/com/jme3/gde/assetpack/project/AssetPackProjectLogicalView.java
@@ -1,10 +1,10 @@
 package com.jme3.gde.assetpack.project;
 
-import com.jme3.gde.assetpack.project.actions.PublishAssetPackAction;
 import com.jme3.gde.assetpack.browser.nodes.AssetPackBrowserFolder;
 import com.jme3.gde.assetpack.project.actions.CleanupProjectAction;
 import com.jme3.gde.assetpack.project.actions.ConvertOgreBinaryMeshesAction;
 import com.jme3.gde.assetpack.project.actions.ImportWorldForgeAction;
+import com.jme3.gde.assetpack.project.actions.PublishAssetPackAction;
 import java.awt.Image;
 import java.util.LinkedList;
 import java.util.List;
@@ -45,7 +45,7 @@ class AssetPackProjectLogicalView implements LogicalViewProvider {
     /** This is the node you actually see in the project tab for the project */
     private static final class ProjectNode extends AbstractNode {
 
-        private InstanceContent instanceContent;
+        private final InstanceContent instanceContent;
         final AssetPackProject project;
 
         public ProjectNode(AssetPackProject project) throws DataObjectNotFoundException {
@@ -91,7 +91,7 @@ class AssetPackProjectLogicalView implements LogicalViewProvider {
     public static final class ProjectLookup extends AbstractLookup {
 
         private static final long serialVersionUID = 1214314412L;
-        private InstanceContent instanceContent;
+        private final InstanceContent instanceContent;
 
         public ProjectLookup(InstanceContent instanceContent) {
             super(instanceContent);
@@ -121,7 +121,7 @@ class AssetPackProjectLogicalView implements LogicalViewProvider {
         }
 
         protected List<Object> createKeys() {
-            LinkedList<Object> ret = new LinkedList<Object>();
+            LinkedList<Object> ret = new LinkedList<>();
             ret.add(new Object());
             return ret;
         }

--- a/jme3-core/src/META-INF/services/org.netbeans.spi.project.ProjectFactory
+++ b/jme3-core/src/META-INF/services/org.netbeans.spi.project.ProjectFactory
@@ -1,1 +1,0 @@
-com.jme3.gde.core.codeless.CodelessProjectFactory

--- a/jme3-core/src/com/jme3/gde/core/codeless/CodelessProject.java
+++ b/jme3-core/src/com/jme3/gde/core/codeless/CodelessProject.java
@@ -11,7 +11,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Properties;
 import javax.swing.Icon;
-import javax.swing.ImageIcon;
 import org.netbeans.api.project.Project;
 import org.netbeans.api.project.ProjectInformation;
 import org.netbeans.spi.project.ActionProvider;
@@ -32,7 +31,7 @@ class CodelessProject implements Project {
     LogicalViewProvider logicalView = new CodelessProjectLogicalView(this);
     private final ProjectState state;
     private Lookup lkp;
-    private ProjectAssetManager projectAssetManager;
+    private final ProjectAssetManager projectAssetManager;
 
     public CodelessProject(FileObject projectDir, ProjectState state) {
         this.projectDir = projectDir;
@@ -122,7 +121,7 @@ class CodelessProject implements Project {
 
     private final class ActionProviderImpl implements ActionProvider {
 
-        private String[] supported = new String[]{
+        private final String[] supported = new String[]{
             ActionProvider.COMMAND_DELETE,
             ActionProvider.COMMAND_COPY,
         };
@@ -156,19 +155,23 @@ class CodelessProject implements Project {
 
     private final class DemoDeleteOperation implements DeleteOperationImplementation {
 
+        @Override
         public void notifyDeleting() throws IOException {
         }
 
+        @Override
         public void notifyDeleted() throws IOException {
         }
 
+        @Override
         public List<FileObject> getMetadataFiles() {
-            List<FileObject> dataFiles = new ArrayList<FileObject>();
+            List<FileObject> dataFiles = new ArrayList<>();
             return dataFiles;
         }
 
+        @Override
         public List<FileObject> getDataFiles() {
-            List<FileObject> dataFiles = new ArrayList<FileObject>();
+            List<FileObject> dataFiles = new ArrayList<>();
             return dataFiles;
         }
     }
@@ -183,17 +186,21 @@ class CodelessProject implements Project {
             this.projectDir = project.getProjectDirectory();
         }
 
+        @Override
         public List<FileObject> getMetadataFiles() {
-            return Collections.EMPTY_LIST;
+            return Collections.emptyList();
         }
 
+        @Override
         public List<FileObject> getDataFiles() {
-            return Collections.EMPTY_LIST;
+            return Collections.emptyList();
         }
 
+        @Override
         public void notifyCopying() throws IOException {
         }
 
+        @Override
         public void notifyCopied(Project arg0, File arg1, String arg2) throws IOException {
         }
     }

--- a/jme3-core/src/com/jme3/gde/core/codeless/CodelessProjectFactory.java
+++ b/jme3-core/src/com/jme3/gde/core/codeless/CodelessProjectFactory.java
@@ -1,23 +1,25 @@
 
 package com.jme3.gde.core.codeless;
 
+import com.jme3.gde.core.icons.IconList;
 import java.io.IOException;
 import org.netbeans.api.project.Project;
+import org.netbeans.api.project.ProjectManager;
 import org.netbeans.spi.project.ProjectFactory;
+import org.netbeans.spi.project.ProjectFactory2;
 import org.netbeans.spi.project.ProjectState;
 import org.openide.filesystems.FileObject;
+import org.openide.util.lookup.ServiceProvider;
 
-public class CodelessProjectFactory implements ProjectFactory {
+@ServiceProvider(service = ProjectFactory.class)
+public class CodelessProjectFactory implements ProjectFactory2 {
 
-    public static final String CONFIG_NAME="assets.jmp";
+    public static final String CONFIG_NAME = "assets.jmp";
 
     //Specifies when a project is a project, i.e. properties file exists
     @Override
     public boolean isProject(FileObject projectDirectory) {
-        if(projectDirectory.getFileObject(CONFIG_NAME)!=null){
-            return true;
-        }
-        return false;
+        return projectDirectory.getFileObject(CONFIG_NAME) != null;
     }
 
     //Specifies when the project will be opened, i.e.,
@@ -36,5 +38,14 @@ public class CodelessProjectFactory implements ProjectFactory {
                     " cannot save project");
         }
     }
-    
+
+    @Override
+    public ProjectManager.Result isProject2(FileObject fo) {
+        if (!isProject(fo)) {
+            return null;
+        }
+
+        return new ProjectManager.Result(IconList.jmeLogo);
+    }
+
 }


### PR DESCRIPTION
- Tidied up some related files
- Use annotations instead of the meta-inf (I understood this is the newer way, seems smarter to me, everything else is already with annotations)
- Implement ProjectFactory2 interface instead of the ProjectFactory

The newer interface speeds up things quite a bit. Now the project wont be loaded for just the preview, instead it is "instantly" recognized. In reality I doubt people have much of these projects laying around to see any speedup :) But hey, now this is up-to-date and ready for someone to copy paste...

I didn't find any place where the normal JME project is actually loaded up. I can see in the open projects dialog that it is recognized. When it is actually loaded, the project view shows the standard java icon instead of the JME icon seen in the open projects dialog.... The asset pack & codeless projects do have the icon even in project view.