### PR TITLE
Ios gl3 and some improvements

### DIFF
--- a/jme3-ios/ios-data/templates/ios.properties
+++ b/jme3-ios/ios-data/templates/ios.properties
@@ -47,7 +47,7 @@ ios.proguard.options=-keep public class com.jme3.system.ios.*{public *;} \
 -keep public class de.lessvoid.nifty.loaderv2.types.** { public *;} \
 -keep public class de.lessvoid.nifty.controls.** { public *; } \
 -keep public class de.lessvoid.nifty.input.** { public *; } \
--keep public class de.lessvoid.nifty.effects.impl.** { public *;}
+-keep public class de.lessvoid.nifty.effects.impl.** { public *;} \
 -keepclassmembers class com.jme3.audio.plugins.NativeVorbisFile{public *;} \
 -keep public class * implements javax.xml.parsers.SAXParserFactory{public *;} \
 -keep public class com.sun.org.apache.xerces.internal.jaxp.SAXParserFactoryImpl \

--- a/jme3-ios/ios-data/templates/project/jme-ios.xcodeproj/project.pbxproj
+++ b/jme3-ios/ios-data/templates/project/jme-ios.xcodeproj/project.pbxproj
@@ -17,6 +17,7 @@
 		08914C20142A826B00991C80 /* MainWindow_iPhone.xib in Resources */ = {isa = PBXBuildFile; fileRef = 08914C1E142A826B00991C80 /* MainWindow_iPhone.xib */; };
 		08914C24142A826B00991C80 /* jmeAppDelegate_iPad.m in Sources */ = {isa = PBXBuildFile; fileRef = 08914C23142A826B00991C80 /* jmeAppDelegate_iPad.m */; };
 		08914C27142A826B00991C80 /* MainWindow_iPad.xib in Resources */ = {isa = PBXBuildFile; fileRef = 08914C25142A826B00991C80 /* MainWindow_iPad.xib */; };
+		BBE3F3AD25E54070009CA0E9 /* Dummy.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = BBE3F3AC25E54070009CA0E9 /* Dummy.storyboard */; };
 		CC69FB0F16374681009585B5 /* OpenGLES.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CC69FB0E16374681009585B5 /* OpenGLES.framework */; };
 		CCD3ADB518AC38BE00FE8DC5 /* OpenAL.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CCD3ADB418AC38BE00FE8DC5 /* OpenAL.framework */; };
 		CCFD653F163755D80020EFDD /* GLKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CCFD653E163755D80020EFDD /* GLKit.framework */; };
@@ -40,6 +41,7 @@
 		08914C22142A826B00991C80 /* jmeAppDelegate_iPad.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = jmeAppDelegate_iPad.h; path = iPad/jmeAppDelegate_iPad.h; sourceTree = "<group>"; };
 		08914C23142A826B00991C80 /* jmeAppDelegate_iPad.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = jmeAppDelegate_iPad.m; path = iPad/jmeAppDelegate_iPad.m; sourceTree = "<group>"; };
 		08914C26142A826B00991C80 /* en */ = {isa = PBXFileReference; lastKnownFileType = file.xib; name = en; path = iPad/en.lproj/MainWindow_iPad.xib; sourceTree = "<group>"; };
+		BBE3F3AC25E54070009CA0E9 /* Dummy.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = Dummy.storyboard; sourceTree = "<group>"; };
 		CC69FB0E16374681009585B5 /* OpenGLES.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = OpenGLES.framework; path = System/Library/Frameworks/OpenGLES.framework; sourceTree = SDKROOT; };
 		CCD3ADB418AC38BE00FE8DC5 /* OpenAL.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = OpenAL.framework; path = System/Library/Frameworks/OpenAL.framework; sourceTree = SDKROOT; };
 		CCFD653E163755D80020EFDD /* GLKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = GLKit.framework; path = System/Library/Frameworks/GLKit.framework; sourceTree = SDKROOT; };
@@ -101,6 +103,7 @@
 				08914C1A142A826B00991C80 /* iPhone */,
 				08914C21142A826B00991C80 /* iPad */,
 				08914C0F142A826B00991C80 /* Supporting Files */,
+				BBE3F3AC25E54070009CA0E9 /* Dummy.storyboard */,
 			);
 			path = "jme-ios";
 			sourceTree = "<group>";
@@ -194,6 +197,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				BBE3F3AD25E54070009CA0E9 /* Dummy.storyboard in Resources */,
 				E9E6261018A052130084FC12 /* logging.properties in Resources */,
 				08914C13142A826B00991C80 /* InfoPlist.strings in Resources */,
 				08914C20142A826B00991C80 /* MainWindow_iPhone.xib in Resources */,
@@ -292,7 +296,7 @@
 					/System/Library/Frameworks/JavaVM.framework/Headers,
 					/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/JavaVM.framework/Headers/,
 				);
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				ONLY_ACTIVE_ARCH = YES;
 				OTHER_LDFLAGS = (
 					"-filelist",
@@ -350,7 +354,7 @@
 					/System/Library/Frameworks/JavaVM.framework/Headers,
 					/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/JavaVM.framework/Headers/,
 				);
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				OTHER_CFLAGS = "-DNS_BLOCK_ASSERTIONS=1";
 				OTHER_LDFLAGS = (
 					"-filelist",
@@ -386,7 +390,8 @@
 					/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/JavaVM.framework/Headers/,
 				);
 				INFOPLIST_FILE = "jme-ios/jme-ios-Info.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				OTHER_CODE_SIGN_FLAGS = "--deep";
 				OTHER_LDFLAGS = (
 					"-filelist",
 					"../../build/ios-arm/libs.list",
@@ -422,7 +427,7 @@
 					/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/JavaVM.framework/Headers/,
 				);
 				INFOPLIST_FILE = "jme-ios/jme-ios-Info.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				OTHER_LDFLAGS = (
 					"-filelist",
 					"../../build/ios-arm/libs.list",

--- a/jme3-ios/ios-data/templates/project/jme-ios/Dummy.storyboard
+++ b/jme3-ios/ios-data/templates/project/jme-ios/Dummy.storyboard
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="15705" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" launchScreen="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina6_1" orientation="portrait" appearance="light"/>
+    <dependencies>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="15706"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <scenes>
+        <!--View Controller-->
+        <scene sceneID="D10-0T-wYE">
+            <objects>
+                <viewController id="hFc-qA-Ss9" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="0DT-pd-vHB">
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                        <viewLayoutGuide key="safeArea" id="Sxt-UA-qxL"/>
+                    </view>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="abh-6n-3aV" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="-172" y="-209"/>
+        </scene>
+    </scenes>
+</document>

--- a/jme3-ios/ios-data/templates/project/jme-ios/jmeAppDelegate.h
+++ b/jme3-ios/ios-data/templates/project/jme-ios/jmeAppDelegate.h
@@ -1,5 +1,6 @@
 #import <UIKit/UIKit.h>
 #import <OpenGLES/ES2/gl.h>
+#import <OpenGLES/ES3/gl.h>
 #import <GLKit/GLKit.h>
 #define __LP64__ 1
 #include <jni.h>

--- a/jme3-ios/ios-data/templates/project/jme-ios/jmeAppDelegate.m
+++ b/jme3-ios/ios-data/templates/project/jme-ios/jmeAppDelegate.m
@@ -37,7 +37,10 @@ getEnv(JavaVM* vm)
     /**
      * GLES Context initialization
      **/
-    _ctx = [[EAGLContext alloc] initWithAPI:kEAGLRenderingAPIOpenGLES2];
+    _ctx = [[EAGLContext alloc] initWithAPI:kEAGLRenderingAPIOpenGLES3];
+    if (_ctx == nil) {
+        _ctx = [[EAGLContext alloc] initWithAPI:kEAGLRenderingAPIOpenGLES2];
+    }
     _glview.context = _ctx;
     _glview.drawableDepthFormat = GLKViewDrawableDepthFormat24;
     _glview.delegate = self;

--- a/jme3-ios/ios-data/templates/project/jme-ios/jmeAppDelegate.m
+++ b/jme3-ios/ios-data/templates/project/jme-ios/jmeAppDelegate.m
@@ -184,6 +184,18 @@ getEnv(JavaVM* vm)
     /*
      Restart any tasks that were paused (or not yet started) while the application was inactive. If the application was previously in the background, optionally refresh the user interface.
      */
+    CGRect originalFrame = [[UIScreen mainScreen] bounds];
+    CGRect frame = [self.glview convertRect:originalFrame fromView:nil];
+    JNIEnv* e = getEnv(self.vm);
+    if (e) {
+        float scale = _glview.contentScaleFactor;
+        (*e)->CallVoidMethod(e, self.harness, self.reshapeMethod, (int)(frame.size.width * scale), (int)(frame.size.height * scale));
+        if ((*e)->ExceptionCheck(e)) {
+            NSLog(@"Could not invoke iOS Harness reshape");
+            (*e)->ExceptionDescribe(e);
+            (*e)->ExceptionClear(e);
+        }
+    }
 }
 
 - (void)applicationWillTerminate:(UIApplication *)application

--- a/jme3-ios/ios-data/templates/project/jme-ios/jmeAppDelegate.m
+++ b/jme3-ios/ios-data/templates/project/jme-ios/jmeAppDelegate.m
@@ -184,18 +184,6 @@ getEnv(JavaVM* vm)
     /*
      Restart any tasks that were paused (or not yet started) while the application was inactive. If the application was previously in the background, optionally refresh the user interface.
      */
-    CGRect originalFrame = [[UIScreen mainScreen] bounds];
-    CGRect frame = [self.glview convertRect:originalFrame fromView:nil];
-    JNIEnv* e = getEnv(self.vm);
-    if (e) {
-        float scale = _glview.contentScaleFactor;
-        (*e)->CallVoidMethod(e, self.harness, self.reshapeMethod, (int)(frame.size.width * scale), (int)(frame.size.height * scale));
-        if ((*e)->ExceptionCheck(e)) {
-            NSLog(@"Could not invoke iOS Harness reshape");
-            (*e)->ExceptionDescribe(e);
-            (*e)->ExceptionClear(e);
-        }
-    }
 }
 
 - (void)applicationWillTerminate:(UIApplication *)application

--- a/jme3-ios/ios-data/templates/src/JmeAppHarness.java
+++ b/jme3-ios/ios-data/templates/src/JmeAppHarness.java
@@ -81,12 +81,14 @@ public class JmeAppHarness extends IosHarness{
         logger.log(Level.FINE, "JmeAppHarness reshape");
         AppSettings settings = app.getContext().getSettings();
         settings.setResolution(width, height);
-        if (renderer != null) {
-    		app.reshape(width, height);
-    	}
-    	if (input != null) {
-    		input.loadSettings(settings);
-    	}
+        if (renderer == null) {
+            renderer = (GLRenderer)app.getContext().getRenderer();
+        }
+        app.reshape(width, height);
+        if (input == null) {
+            input = (IosInputHandler)app.getContext().getTouchInput();
+        }
+        input.loadSettings(settings);
     }
     
     public void injectTouchBegin(int pointerId, long time, float x, float y) {

--- a/jme3-ios/ios-data/templates/src/JmeAppHarness.java
+++ b/jme3-ios/ios-data/templates/src/JmeAppHarness.java
@@ -1,5 +1,6 @@
 import com.jme3.system.ios.IosHarness;
 import com.jme3.input.ios.IosInputHandler;
+import com.jme3.math.Vector2f;
 import com.jme3.renderer.opengl.GLRenderer;
 import com.jme3.system.JmeContext;
 import com.jme3.system.AppSettings;
@@ -18,6 +19,7 @@ public class JmeAppHarness extends IosHarness{
 	protected GLRenderer renderer;
 	protected IosInputHandler input;
 	protected boolean autoFlush = true;
+	protected Vector2f resizePending = null;
 
 
     /**
@@ -62,17 +64,21 @@ public class JmeAppHarness extends IosHarness{
     @Override
     public void appDraw() {
         logger.log(Level.FINE, "JmeAppHarness appDraw");
-		if (renderer == null) {
-			JmeContext iosContext = app.getContext();
-			renderer = (GLRenderer)iosContext.getRenderer();
-			renderer.initialize();
-			input = (IosInputHandler)iosContext.getTouchInput();
-			input.initialize();
-		} else {
-			app.update();
+        if (renderer == null) {
+            JmeContext iosContext = app.getContext();
+            renderer = (GLRenderer)iosContext.getRenderer();
+            renderer.initialize();
+            input = (IosInputHandler)iosContext.getTouchInput();
+            input.initialize();
+        } else {
+            if(resizePending != null) {
+                appReshape((int)resizePending.x, (int)resizePending.y);
+                resizePending = null;
+            }
+            app.update();
     	    if (autoFlush) {
-        	    renderer.postFrame();
-        	}
+                renderer.postFrame();
+            }
         }
     }
     
@@ -81,14 +87,16 @@ public class JmeAppHarness extends IosHarness{
         logger.log(Level.FINE, "JmeAppHarness reshape");
         AppSettings settings = app.getContext().getSettings();
         settings.setResolution(width, height);
-        if (renderer == null) {
-            renderer = (GLRenderer)app.getContext().getRenderer();
+        if (renderer != null) {
+            app.reshape(width, height);
+            resizePending = null;
+        } else {
+            resizePending = new Vector2f(width, height);
         }
-        app.reshape(width, height);
-        if (input == null) {
-            input = (IosInputHandler)app.getContext().getTouchInput();
+
+        if (input != null) {
+            input.loadSettings(settings);
         }
-        input.loadSettings(settings);
     }
     
     public void injectTouchBegin(int pointerId, long time, float x, float y) {

--- a/jme3-ios/ios-data/templates/src/JmeIosGLES.m
+++ b/jme3-ios/ios-data/templates/src/JmeIosGLES.m
@@ -2025,7 +2025,7 @@ Java_com_jme3_renderer_ios_JmeIosGLES_glDrawElementsInstanced(JNIEnv* e, jobject
         (GLenum) mode,
         (GLsizei) count,
         (GLenum) type,
-        (const void *) indices, // TODO: lwjgl uses intptr_t insead, double check it works properly
+        (const void *) indices,
         (GLsizei) primcount
     );
 }

--- a/jme3-ios/ios-data/templates/src/JmeIosGLES.m
+++ b/jme3-ios/ios-data/templates/src/JmeIosGLES.m
@@ -1332,7 +1332,7 @@ Java_com_jme3_renderer_ios_JmeIosGLES_glTexParameterf(JNIEnv* e, jobject c, jint
     );
 }
 
-JJNIEXPORT void JNICALL
+JNIEXPORT void JNICALL
 Java_com_jme3_renderer_ios_JmeIosGLES_glTexSubImage2D(JNIEnv* e, jobject c, jint target, jint level, jint xoffset, jint yoffset, jint width, jint height, jint format, jint type, jobject pixels_buf) {
     jarray _array = (jarray) 0;
     jint _bufferOffset = (jint) 0;

--- a/jme3-ios/ios-data/templates/src/JmeIosGLES.m
+++ b/jme3-ios/ios-data/templates/src/JmeIosGLES.m
@@ -820,6 +820,28 @@ exit:
     return (jint)_returnValue;
 }
 
+JNIEXPORT void JNICALL
+Java_com_jme3_renderer_ios_JmeIosGLES_glGetBoolean(JNIEnv* e, jobject c, jint pname, jobject params_buf) {
+    jarray _array = (jarray) 0;
+    jint _bufferOffset = (jint) 0;
+    jint _remaining;
+    GLvoid *params = (GLvoid *) 0;
+
+    if (params_buf) {
+        params = (GLvoid *)getPointer(e, params_buf, &_array, &_remaining, &_bufferOffset);
+    }
+    if (params_buf && params == NULL) {
+        char * _paramsBase = (char *)(*e)->GetPrimitiveArrayCritical(e, _array, (jboolean *) 0);
+        params = (GLvoid *) (_paramsBase + _bufferOffset);
+    }
+      
+    glGetBooleanv(
+        (GLenum) pname,
+        (GLboolean *) params
+    );
+}
+
+
 JNIEXPORT jint JNICALL
 Java_com_jme3_renderer_ios_JmeIosGLES_glGetError(JNIEnv* e, jobject c) {
     GLenum _returnValue;
@@ -1106,6 +1128,15 @@ exit:
 }
 
 JNIEXPORT jboolean JNICALL
+Java_com_jme3_renderer_ios_JmeIosGLES_glIsEnabled(JNIEnv* e, jobject c, jint cap) {
+    GLboolean _returnValue;
+    _returnValue = glIsEnabled(
+        (GLenum)cap
+    );
+    return (jboolean)_returnValue;
+}
+
+JNIEXPORT jboolean JNICALL
 Java_com_jme3_renderer_ios_JmeIosGLES_glIsFramebuffer(JNIEnv* e, jobject c, jint framebuffer) {
     GLboolean _returnValue;
     _returnValue = glIsFramebuffer(
@@ -1231,6 +1262,26 @@ Java_com_jme3_renderer_ios_JmeIosGLES_glShaderSource(JNIEnv* e, jobject c, jint 
 	//glShaderSource(shader, 1, code, length);
 	
 	(*e)->ReleaseStringUTFChars(e, string, stringNative);
+}
+
+JNIEXPORT void JNICALL
+Java_com_jme3_renderer_ios_JmeIosGLES_glStencilFuncSeparate(JNIEnv* e, jobject c, jint face, jint func, jint ref, jint mask) {
+    glStencilFuncSeparate(
+        (GLenum) face,
+        (GLenum) func,
+        (GLint) ref,
+        (GLuint) mask
+    );
+}
+
+JNIEXPORT void JNICALL
+Java_com_jme3_renderer_ios_JmeIosGLES_glStencilOpSeparate(JNIEnv* e, jobject c, jint face, jint sfail, jint dpfail, jint dppass) {
+    glStencilOpSeparate(
+        (GLenum) face,
+        (GLenum) sfail,
+        (GLenum) dpfail,
+        (GLenum) dppass
+    );
 }
 
 JNIEXPORT void JNICALL

--- a/jme3-ios/ios-data/templates/src/JmeIosGLES.m
+++ b/jme3-ios/ios-data/templates/src/JmeIosGLES.m
@@ -1967,7 +1967,7 @@ Java_com_jme3_renderer_ios_JmeIosGLES_glDrawElementsInstanced(JNIEnv* e, jobject
         (GLsizei) count,
         (GLenum) type,
         (const void *) indices, // TODO: lwjgl uses intptr_t insead, double check it works properly
-        (GLsizei) instancecount
+        (GLsizei) primcount
     );
 }
 
@@ -2017,7 +2017,7 @@ Java_com_jme3_renderer_ios_JmeIosGLES_glCompressedTexImage3D(JNIEnv* e, jobject 
     glCompressedTexImage3D(
         (GLenum) target,
         (GLint) level,
-        (GLenum) internalformat,
+        (GLenum) internalFormat,
         (GLsizei) width,
         (GLsizei) height,
         (GLsizei) depth,
@@ -2047,7 +2047,7 @@ Java_com_jme3_renderer_ios_JmeIosGLES_glCompressedTexSubImage3D(JNIEnv* e, jobje
         pixels = (GLvoid *) (_pixelsBase + _bufferOffset);
     }
         
-    glCompressedTexImage3D(
+    glCompressedTexSubImage3D(
         (GLenum) target,
         (GLint) level,
         (GLint) xoffset,

--- a/jme3-ios/ios-data/templates/src/JmeIosGLES.m
+++ b/jme3-ios/ios-data/templates/src/JmeIosGLES.m
@@ -1961,7 +1961,6 @@ exit:
 JNIEXPORT void JNICALL 
 Java_com_jme3_renderer_ios_JmeIosGLES_glDrawElementsInstanced(JNIEnv* e, jobject c, jint mode, jint count, jint type, jlong indices, jint primcount)
 {
-    intptr_t
     glDrawElementsInstanced(
         (GLenum) mode,
         (GLsizei) count,

--- a/jme3-ios/ios-data/templates/src/JmeIosGLES.m
+++ b/jme3-ios/ios-data/templates/src/JmeIosGLES.m
@@ -1273,6 +1273,15 @@ Java_com_jme3_renderer_ios_JmeIosGLES_glTexParameteri(JNIEnv* e, jobject c, jint
 }
 
 JNIEXPORT void JNICALL
+Java_com_jme3_renderer_ios_JmeIosGLES_glTexParameterf(JNIEnv* e, jobject c, jint target, jint pname, jfloat param) {
+    glTexParameterf(
+        (GLenum)target,
+        (GLenum)pname,
+        (GLfloat)param
+    );
+}
+
+JJNIEXPORT void JNICALL
 Java_com_jme3_renderer_ios_JmeIosGLES_glTexSubImage2D(JNIEnv* e, jobject c, jint target, jint level, jint xoffset, jint yoffset, jint width, jint height, jint format, jint type, jobject pixels_buf) {
     jarray _array = (jarray) 0;
     jint _bufferOffset = (jint) 0;

--- a/jme3-ios/ios-data/templates/src/JmeIosGLES.m
+++ b/jme3-ios/ios-data/templates/src/JmeIosGLES.m
@@ -3,9 +3,11 @@
 #import <jni.h>
 #import <OpenGLES/ES2/gl.h>
 #import <OpenGLES/ES2/glext.h>
+#import <OpenGLES/ES3/gl.h>
+#import <OpenGLES/ES3/glext.h>
 
 /**
- * Author: Kostyantyn Hushchyn
+ * Author: Kostyantyn Hushchyn, Jesus Oliver
  */
 
 #ifndef JNIEXPORT
@@ -1743,6 +1745,396 @@ Java_com_jme3_renderer_ios_JmeIosGLES_glViewport(JNIEnv* e, jobject c, jint x, j
         (GLsizei)height
     );
 }
+
+JNIEXPORT void JNICALL 
+Java_com_jme3_renderer_ios_JmeIosGLES_glBeginQuery(JNIEnv* e, jobject c, jint target, jint query) {
+    glBeginQuery(
+        (GLint) target,
+        (GLint) query
+    );
+}
+
+JNIEXPORT void JNICALL 
+Java_com_jme3_renderer_ios_JmeIosGLES_glEndQuery(JNIEnv* e, jobject c, jint target)
+{
+    glEndQuery((GLint)target);
+}
+
+JNIEXPORT void JNICALL 
+Java_com_jme3_renderer_ios_JmeIosGLES_glGenQueries(JNIEnv* e, jobject c, jint count, jobject v_buf)
+{
+    jint _exception = 0;
+    const char * _exceptionType = NULL;
+    const char * _exceptionMessage = NULL;
+    jarray _array = (jarray) 0;
+    jint _bufferOffset = (jint) 0;
+    jint _remaining;
+    GLint *v = (GLint *) 0;
+
+    v = (GLint *)getPointer(e, v_buf, &_array, &_remaining, &_bufferOffset);
+    if (_remaining < count) {
+        _exception = 1;
+        _exceptionType = "java/lang/IllegalArgumentException";
+        _exceptionMessage = "remaining() < count < needed";
+        goto exit;
+    }
+    if (v == NULL) {
+        char * _vBase = (char *)(*e)->GetPrimitiveArrayCritical(e, _array, (jboolean *) 0);
+        v = (GLint *) (_vBase + _bufferOffset);
+    }
+    glGenQueries(
+        (GLsizei)count,
+        (GLint *)v
+    );
+
+exit:
+    if (_array) {
+        releasePointer(e, _array, v, JNI_FALSE);
+    }
+    if (_exception) {
+        jniThrowException(e, _exceptionType, _exceptionMessage);
+    }
+}
+
+JNIEXPORT void JNICALL 
+Java_com_jme3_renderer_ios_JmeIosGLES_glGetQueryObjectuiv(JNIEnv* e, jobject c, jint query, jint pname, jintArray params_ref)
+{
+    jint _exception = 0;
+    const char * _exceptionType;
+    const char * _exceptionMessage;
+    GLint *params_base = (GLint *) 0;
+    jint _remaining;
+    GLint *params = (GLint *) 0;
+    int _needed = 0;
+
+    if (!params_ref) {
+        _exception = 1;
+        _exceptionType = "java/lang/IllegalArgumentException";
+        _exceptionMessage = "params == null";
+        goto exit;
+    }
+
+    _remaining = (*e)->GetArrayLength(e, params_ref);
+    _needed = getNeededCount(pname);
+    // if we didn't find this pname, we just assume the user passed
+    // an array of the right size -- this might happen with extensions
+    // or if we forget an enum here.
+    if (_remaining < _needed) {
+        _exception = 1;
+        _exceptionType = "java/lang/IllegalArgumentException";
+        _exceptionMessage = "length < needed";
+        goto exit;
+    }
+    params_base = (GLint *)
+        (*e)->GetPrimitiveArrayCritical(e, params_ref, (jboolean *)0);
+    params = params_base;
+
+    glGetQueryObjectuiv(
+        (GLint)query,
+        (GLenum)pname,
+        (GLint *)params
+    );
+
+exit:
+    if (params_base) {
+        (*e)->ReleasePrimitiveArrayCritical(e, params_ref, params_base,
+            _exception ? JNI_ABORT: 0);
+    }
+    if (_exception) {
+        jniThrowException(e, _exceptionType, _exceptionMessage);
+    }
+}
+
+JNIEXPORT void JNICALL 
+Java_com_jme3_renderer_ios_JmeIosGLES_glGetQueryiv(JNIEnv* e, jobject c, jint target, jint pname, jintArray params_ref)
+{
+    jint _exception = 0;
+    const char * _exceptionType;
+    const char * _exceptionMessage;
+    GLint *params_base = (GLint *) 0;
+    jint _remaining;
+    GLint *params = (GLint *) 0;
+    int _needed = 0;
+
+    if (!params_ref) {
+        _exception = 1;
+        _exceptionType = "java/lang/IllegalArgumentException";
+        _exceptionMessage = "params == null";
+        goto exit;
+    }
+
+    _remaining = (*e)->GetArrayLength(e, params_ref);
+    _needed = getNeededCount(pname);
+    // if we didn't find this pname, we just assume the user passed
+    // an array of the right size -- this might happen with extensions
+    // or if we forget an enum here.
+    if (_remaining < _needed) {
+        _exception = 1;
+        _exceptionType = "java/lang/IllegalArgumentException";
+        _exceptionMessage = "length < needed";
+        goto exit;
+    }
+    params_base = (GLint *)
+        (*e)->GetPrimitiveArrayCritical(e, params_ref, (jboolean *)0);
+    params = params_base;
+
+    glGetQueryiv(
+        (GLenum)target,
+        (GLenum)pname,
+        (GLint *)params
+    );
+
+exit:
+    if (params_base) {
+        (*e)->ReleasePrimitiveArrayCritical(e, params_ref, params_base,
+            _exception ? JNI_ABORT: 0);
+    }
+    if (_exception) {
+        jniThrowException(e, _exceptionType, _exceptionMessage);
+    }
+}
+
+JNIEXPORT void JNICALL 
+Java_com_jme3_renderer_ios_JmeIosGLES_glBlitFramebuffer(JNIEnv* e, jobject c, jint srcX0, jint srcY0, jint srcX1, jint srcY1, jint dstX0, jint dstY0, jint dstX1, jint dstY1, jint mask, jint filter)
+{
+    glBlitFramebuffer( 	
+        (GLint) srcX0,
+        (GLint) srcY0,
+        (GLint) srcX1,
+        (GLint) srcY1,
+        (GLint) dstX0,
+        (GLint) dstY0,
+        (GLint) dstX1,
+        (GLint) dstY1,
+        (GLbitfield) mask,
+        (GLenum) filter
+    );
+}
+
+JNIEXPORT void JNICALL 
+Java_com_jme3_renderer_ios_JmeIosGLES_glDrawArraysInstanced(JNIEnv* e, jobject c, jint mode, jint first, jint count, jint primcount)
+{
+    glDrawArraysInstanced(
+        (GLenum) mode,
+        (GLint) first,
+        (GLsizei) count,
+        (GLsizei) primcount
+    );
+}
+
+JNIEXPORT void JNICALL 
+Java_com_jme3_renderer_ios_JmeIosGLES_glDrawBuffers(JNIEnv* e, jobject c, jint count, jobject v_buf)
+{
+    jint _exception = 0;
+    const char * _exceptionType = NULL;
+    const char * _exceptionMessage = NULL;
+    jarray _array = (jarray) 0;
+    jint _bufferOffset = (jint) 0;
+    jint _remaining;
+    GLint *v = (GLint *) 0;
+
+    v = (GLint *)getPointer(e, v_buf, &_array, &_remaining, &_bufferOffset);
+    if (_remaining < count) {
+        _exception = 1;
+        _exceptionType = "java/lang/IllegalArgumentException";
+        _exceptionMessage = "remaining() < count < needed";
+        goto exit;
+    }
+    if (v == NULL) {
+        char * _vBase = (char *)(*e)->GetPrimitiveArrayCritical(e, _array, (jboolean *) 0);
+        v = (GLint *) (_vBase + _bufferOffset);
+    }
+    glDrawBuffers(
+        (GLsizei)count,
+        (GLint *)v
+    );
+
+exit:
+    if (_array) {
+        releasePointer(e, _array, v, JNI_FALSE);
+    }
+    if (_exception) {
+        jniThrowException(e, _exceptionType, _exceptionMessage);
+    }
+}
+
+JNIEXPORT void JNICALL 
+Java_com_jme3_renderer_ios_JmeIosGLES_glDrawElementsInstanced(JNIEnv* e, jobject c, jint mode, jint count, jint type, jlong indices, jint primcount)
+{
+    intptr_t
+    glDrawElementsInstanced(
+        (GLenum) mode,
+        (GLsizei) count,
+        (GLenum) type,
+        (const void *) indices, // TODO: lwjgl uses intptr_t insead, double check it works properly
+        (GLsizei) instancecount
+    );
+}
+
+JNIEXPORT void JNICALL 
+Java_com_jme3_renderer_ios_JmeIosGLES_glVertexAttribDivisor(JNIEnv* e, jobject c, jint index, jint divisor)
+{
+    glVertexAttribDivisor(
+        (GLint) index,
+        (GLint) divisor
+    );
+}
+
+JNIEXPORT void JNICALL 
+Java_com_jme3_renderer_ios_JmeIosGLES_glFramebufferTextureLayer(JNIEnv* e, jobject c, jint target, jint attachment, jint texture, jint level, jint layer)
+{
+    glFramebufferTextureLayer(
+        (GLenum) target,
+        (GLenum) attachment,
+        (GLuint) texture,
+        (GLint) level,
+        (GLint) layer
+    );
+}
+
+JNIEXPORT void JNICALL 
+Java_com_jme3_renderer_ios_JmeIosGLES_glReadBuffer(JNIEnv* e, jobject c, jint src)
+{
+    glReadBuffer((GLenum) src);
+}
+
+JNIEXPORT void JNICALL 
+Java_com_jme3_renderer_ios_JmeIosGLES_glCompressedTexImage3D(JNIEnv* e, jobject c, jint target, jint level, jint internalFormat, jint width, jint height, jint depth, jint border, jint imageSize, jobject pixels_buf)
+{
+    jarray _array = (jarray) 0;
+    jint _bufferOffset = (jint) 0;
+    jint _remaining;
+    GLvoid *pixels = (GLvoid *) 0;
+
+    if (pixels_buf) {
+        pixels = (GLvoid *)getPointer(e, pixels_buf, &_array, &_remaining, &_bufferOffset);
+    }
+    if (pixels_buf && pixels == NULL) {
+        char * _pixelsBase = (char *)(*e)->GetPrimitiveArrayCritical(e, _array, (jboolean *) 0);
+        pixels = (GLvoid *) (_pixelsBase + _bufferOffset);
+    }
+        
+    glCompressedTexImage3D(
+        (GLenum) target,
+        (GLint) level,
+        (GLenum) internalformat,
+        (GLsizei) width,
+        (GLsizei) height,
+        (GLsizei) depth,
+        (GLint) border,
+        (GLsizei) imageSize,
+        (GLvoid *)pixels
+    );
+
+    if (_array) {
+        releasePointer(e, _array, pixels, JNI_FALSE);
+    }
+}
+
+JNIEXPORT void JNICALL 
+Java_com_jme3_renderer_ios_JmeIosGLES_glCompressedTexSubImage3D(JNIEnv* e, jobject c, jint target, jint level, jint xoffset, jint yoffset, jint zoffset, jint width, jint height, jint depth, jint format, jint imageSize, jobject pixels_buf)
+{
+    jarray _array = (jarray) 0;
+    jint _bufferOffset = (jint) 0;
+    jint _remaining;
+    GLvoid *pixels = (GLvoid *) 0;
+
+    if (pixels_buf) {
+        pixels = (GLvoid *)getPointer(e, pixels_buf, &_array, &_remaining, &_bufferOffset);
+    }
+    if (pixels_buf && pixels == NULL) {
+        char * _pixelsBase = (char *)(*e)->GetPrimitiveArrayCritical(e, _array, (jboolean *) 0);
+        pixels = (GLvoid *) (_pixelsBase + _bufferOffset);
+    }
+        
+    glCompressedTexImage3D(
+        (GLenum) target,
+        (GLint) level,
+        (GLint) xoffset,
+        (GLint) yoffset,
+        (GLint) zoffset,
+        (GLsizei) width,
+        (GLsizei) height,
+        (GLsizei) depth,
+        (GLenum) format,
+        (GLsizei) imageSize,
+        (GLvoid *)pixels
+    );
+
+    if (_array) {
+        releasePointer(e, _array, pixels, JNI_FALSE);
+    }
+}
+
+JNIEXPORT void JNICALL 
+Java_com_jme3_renderer_ios_JmeIosGLES_glTexImage3D(JNIEnv* e, jobject c, jint target, jint level, jint internalFormat, jint width, jint height, jint depth, jint border, jint format, jint type, jobject pixels_buf)
+{
+    jarray _array = (jarray) 0;
+    jint _bufferOffset = (jint) 0;
+    jint _remaining;
+    GLvoid *pixels = (GLvoid *) 0;
+
+    if (pixels_buf) {
+        pixels = (GLvoid *)getPointer(e, pixels_buf, &_array, &_remaining, &_bufferOffset);
+    }
+    if (pixels_buf && pixels == NULL) {
+        char * _pixelsBase = (char *)(*e)->GetPrimitiveArrayCritical(e, _array, (jboolean *) 0);
+        pixels = (GLvoid *) (_pixelsBase + _bufferOffset);
+    }
+        
+    glTexImage3D(
+        (GLenum) target,
+        (GLint) level,
+        (GLint) internalFormat,
+        (GLsizei) width,
+        (GLsizei) height,
+        (GLsizei) depth,
+        (GLint) border,
+        (GLenum) format,
+        (GLenum) type,
+        (GLvoid *)pixels
+    );
+
+    if (_array) {
+        releasePointer(e, _array, pixels, JNI_FALSE);
+    }
+}
+
+JNIEXPORT void JNICALL 
+Java_com_jme3_renderer_ios_JmeIosGLES_glTexSubImage3D(JNIEnv* e, jobject c, jint target, jint level, jint xoffset, jint yoffset, jint zoffset, jint width, jint height, jint depth, jint format, jint type, jobject pixels_buf)
+{
+    jarray _array = (jarray) 0;
+    jint _bufferOffset = (jint) 0;
+    jint _remaining;
+    GLvoid *pixels = (GLvoid *) 0;
+
+    if (pixels_buf) {
+        pixels = (GLvoid *)getPointer(e, pixels_buf, &_array, &_remaining, &_bufferOffset);
+    }
+    if (pixels_buf && pixels == NULL) {
+        char * _pixelsBase = (char *)(*e)->GetPrimitiveArrayCritical(e, _array, (jboolean *) 0);
+        pixels = (GLvoid *) (_pixelsBase + _bufferOffset);
+    }
+        
+    glTexSubImage3D(
+        (GLenum) target,
+        (GLint) level,
+        (GLint) xoffset,
+        (GLint) yoffset,
+        (GLint) zoffset,
+        (GLsizei) width,
+        (GLsizei) height,
+        (GLsizei) depth,
+        (GLenum) format,
+        (GLenum) type,
+        (GLvoid *)pixels
+    );
+
+    if (_array) {
+        releasePointer(e, _array, pixels, JNI_FALSE);
+    }
+}
+
 
 static int
 allowIndirectBuffers(JNIEnv *e) {

--- a/jme3-ios/src/com/jme3/gde/ios/ios-targets.xml
+++ b/jme3-ios/src/com/jme3/gde/ios/ios-targets.xml
@@ -90,6 +90,7 @@
     <target name="-compile-ios-java" description="Compiles the java classes for iOS">
         <mkdir dir="${ios.java.classes.dir}"/>
         <javac
+            source="1.8"
             target="1.8"
             destdir="${ios.java.classes.dir}"
             srcdir="${ios.cc.source.dir}"

--- a/jme3-ios/src/com/jme3/gde/ios/ios-targets.xml
+++ b/jme3-ios/src/com/jme3/gde/ios/ios-targets.xml
@@ -90,6 +90,7 @@
     <target name="-compile-ios-java" description="Compiles the java classes for iOS">
         <mkdir dir="${ios.java.classes.dir}"/>
         <javac
+            target="1.8"
             destdir="${ios.java.classes.dir}"
             srcdir="${ios.cc.source.dir}"
             classpath="${run.classpath}"/>


### PR DESCRIPTION
List of changes:

- Fixed proguard rules.
- Added openGLES3 initialization.
- Implemented native code of missing methods of gles2.
- Implemented native code of gles3 methods.
- Forced compilation using java 8.
- Added Dummy.storyboard to be used as "Launch Screen File" in xcode to avoid bad aspect ratio and being able to use the whole screen and the proper resolution.
- Updated iPhone target to 9.0.

I'm just missing one detail, if I do need to replace also ./src/com/jme3/gde/ios/ios-data.zip or is it regenerated on SDK build?

Topic at hub: https://hub.jmonkeyengine.org/t/ios-improvements-including-gles3-0/44332

** This PR needs the related engine PR: https://github.com/jMonkeyEngine/jmonkeyengine/pull/1473