### PR TITLE
fixes #339 Attribute nodes are expected to be named "Attr"

### DIFF
--- a/jme3-materialeditor/src/com/jme3/gde/materialdefinition/editor/ShaderNodePanel.java
+++ b/jme3-materialeditor/src/com/jme3/gde/materialdefinition/editor/ShaderNodePanel.java
@@ -194,7 +194,7 @@ public class ShaderNodePanel extends NodePanel implements InOut,
                 break;
             case Attribute:
                 header.setIcon(Icons.attrib);
-                setNameAndTitle("Attribute"); // sets text _and_ tooltip the same
+                setNameAndTitle("Attr");
                 break;
             case WorldParam:
                 header.setIcon(Icons.world);


### PR DESCRIPTION
This fix is includes in my behemoth PR as well, although refactoring makes it differ slightly. I figure it's better if I can produce a couple of smaller PR's, then merge them (and deal with the conflicts) before someone tackles the big PR.