### PR TITLE
Get the latest JDK 11

### DIFF
--- a/jdks/download-jdks.sh
+++ b/jdks/download-jdks.sh
@@ -11,8 +11,8 @@
 set -e # Quit on Error
 
 jdk_major_version="11"
-jdk_version="0.14.1"
-jdk_build_version="1"
+jdk_version="0.15"
+jdk_build_version="10"
 platforms=( "x64_linux" "x86-32_windows" "x64_windows" "x64_mac" )
 
 # DEPRECATED (not required anymore)


### PR DESCRIPTION
Just a simple JDK update. Scripts still work. I use this version myself and it has been out for some time now.