### PR TITLE
Removed reference to old jme-bullet.jar and point to jbullet

### DIFF
--- a/BasicGameTemplate/nbproject/project.properties
+++ b/BasicGameTemplate/nbproject/project.properties
@@ -42,15 +42,14 @@ javac.classpath=\
     ${libs.jme3-lwjgl.classpath}:\
     ${libs.jme3-effects.classpath}:\
     ${libs.jme3-terrain.classpath}:\
-    ${libs.jme3-bullet.classpath}:\
-    ${libs.jme3-bullet-native.classpath}
+    ${libs.jme3-jbullet.classpath}
 # Space-separated list of extra javac options
 javac.compilerargs=
 javac.deprecation=false
 javac.processorpath=\
     ${javac.classpath}
-javac.source=1.7
-javac.target=1.7
+javac.source=11
+javac.target=11
 javac.test.classpath=\
     ${javac.classpath}:\
     ${build.classes.dir}
@@ -66,7 +65,7 @@ javadoc.use=true
 javadoc.version=false
 javadoc.windowtitle=
 jaxbwiz.endorsed.dirs="${netbeans.home}/../ide12/modules/ext/jaxb/api"
-jme.project.version=3.1
+jme.project.version=3.4.1
 jnlp.codebase.type=local
 jnlp.descriptor=application
 jnlp.enabled=false


### PR DESCRIPTION
When creating a BasicGame in the SDK with the Ant build system it was still referencing the removed jme-bullet.jar.
I changed it to rather point to the jbullet implementation of the physics engine.
Also updated the javac.source and javac.target to JAVA 11.