### PR TITLE
Unify and fix the game template strings

### DIFF
--- a/jme3-templates/src/com/jme3/gde/templates/Bundle.properties
+++ b/jme3-templates/src/com/jme3/gde/templates/Bundle.properties
@@ -4,4 +4,5 @@ OpenIDE-Module-Long-Description=\
     This plugin contains the basic project templates
 OpenIDE-Module-Name=Project Templates
 OpenIDE-Module-Short-Description=Provides Project Templates
-Templates/Project/JME3/BasicGameProject.zip=BasicGame
+Templates/Project/JME3/BasicGameProject.zip=Basic Game (with Ant)
+Templates/Project/JME3/GradleDesktopGameProject.zip=Basic Game (with Gradle)

--- a/jme3-templates/src/com/jme3/gde/templates/basic/BasicGameDescription.html
+++ b/jme3-templates/src/com/jme3/gde/templates/basic/BasicGameDescription.html
@@ -4,6 +4,6 @@
         <title></title>
     </head>
     <body>
-        This is the basic jme3 application template for any kind of jME3 project.
+        This is the basic jME3 application template for any kind of jME3 project. Uses Ant build system.
     </body>
 </html>

--- a/jme3-templates/src/com/jme3/gde/templates/gradledesktop/GradleDesktopGameDescription.html
+++ b/jme3-templates/src/com/jme3/gde/templates/gradledesktop/GradleDesktopGameDescription.html
@@ -4,6 +4,7 @@
         <title></title>
     </head>
     <body>
-        This is the basic jme3 gradle application template for any kind of jME3 project.
+        This is the basic jME3 application template for any kind of jME3 project. Uses Gradle build system.
+		Gradle is a modern build system with dependency management. Recommended over the Ant build system.
     </body>
 </html>


### PR DESCRIPTION
This fixes the error stack appearing in the IDE logs (#363). Also unifies the template descriptions, also with the ones already offered by NB itself. Added a bit more description and a recommendation to Grade.

![image](https://user-images.githubusercontent.com/8344766/189479523-7af0ae7b-2b11-433b-805c-2d6b34a9b6e5.png)
