### PR TITLE
fix JmeTests project requirement

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -330,7 +330,7 @@ copyProjectLibs.inputs.files configurations.optlibs.resolve()
 copyProjectLibs.inputs.files configurations.testdatalibs.resolve()
 copyProjectLibs.outputs.dir "jme3-project-baselibs/release/libs/"
 copyProjectLibs.outputs.dir "jme3-project-libraries/release/libs/"
-copyProjectLibs.outputs.dir "jme3-project-testdata/release/libs/"
+copyProjectLibs.outputs.dir "jme3-project-testdata/release/modules/ext/"
 
 // workaround method to add a tag with the name "name" and "file" to an XML MarkupBuilder
 def makeName(builder, nameR) { builder.name nameR }

--- a/jme3-project-testdata/src/com/jme3/gde/project/testdata/jme3-test-data.xml
+++ b/jme3-project-testdata/src/com/jme3/gde/project/testdata/jme3-test-data.xml
@@ -10,7 +10,7 @@ and open the template in the editor.
     <localizing-bundle>com.jme3.gde.project.testdata.Bundle</localizing-bundle>
     <volume>
         <type>classpath</type>
-        <resource>jar:nbinst://com.jme3.gde.project.testdata/release/modules/ext/jme3-testdata.jar!/</resource>
+        <resource>jar:nbinst://com.jme3.gde.project.testdata/modules/ext/jme3-testdata.jar!/</resource>
     </volume>
     <volume>
         <type>src</type>


### PR DESCRIPTION
build.gradle might not be required, but i noticed a path that wasn't updated. the fix is in jme-test-data.xml