### PR TITLE
ExternalChangeScanner bug fixes and improvement

### DIFF
--- a/jme3-core/src/com/jme3/gde/core/assets/ExternalChangeScanner.java
+++ b/jme3-core/src/com/jme3/gde/core/assets/ExternalChangeScanner.java
@@ -135,7 +135,7 @@ public class ExternalChangeScanner implements AssetDataPropertyChangeListener,
                 JPanel panel = new JPanel();
                 panel.setLayout(new BorderLayout());
                 panel.add(new JLabel("Original file for "
-                                + assetDataObject.getName() + " changed\nTry "
+                                + assetDataObject.getName() + " changed\n Try "
                                 + "and reapply data to j3o file?"), BorderLayout.NORTH);
                 JCheckBox rememberSelectionBox = new JCheckBox("Remember selection");
                 rememberSelectionBox.setSelected(savedOption != null);


### PR DESCRIPTION
New feature:
Remember this option for ExternalChangeScanner. Fixes #343 
Bug fixes:
Exception for not executing on awt thread
Handling closing window without selecting an option
![Screenshot from 2022-12-27 15-53-48](https://user-images.githubusercontent.com/7988802/209719049-f8a8c5f5-5c9c-4428-ab5d-4083d11caff1.png)


