### PR TITLE
Improve ProjectAssetManager's Gradle support

### DIFF
--- a/jme3-core/src/com/jme3/gde/core/assets/ProjectAssetManager.java
+++ b/jme3-core/src/com/jme3/gde/core/assets/ProjectAssetManager.java
@@ -37,6 +37,7 @@ import com.jme3.asset.AssetManager;
 import com.jme3.asset.DesktopAssetManager;
 import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
+import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
@@ -45,9 +46,11 @@ import java.net.URLClassLoader;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Enumeration;
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Set;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import org.netbeans.api.java.classpath.ClassPath;
@@ -57,6 +60,9 @@ import org.netbeans.api.project.ProjectManager;
 import org.netbeans.api.project.ProjectUtils;
 import org.netbeans.api.project.SourceGroup;
 import org.netbeans.api.project.Sources;
+import org.netbeans.modules.gradle.api.GradleBaseProject;
+import org.netbeans.modules.gradle.java.api.GradleJavaProject;
+import org.netbeans.modules.gradle.java.api.GradleJavaSourceSet;
 import org.openide.DialogDisplayer;
 import org.openide.NotifyDescriptor;
 import org.openide.filesystems.FileAttributeEvent;
@@ -179,9 +185,49 @@ public class ProjectAssetManager extends DesktopAssetManager {
                     }
                 }
             }
+            
+            // Gradle
+            FileObject rootDir = FileUtil.toFileObject(GradleBaseProject.get(project).getRootDir());
+            Set<File> runtimeFiles = new HashSet<>();
+            try {
+                Project rootPrj = ProjectManager.getDefault().findProject(rootDir);
+                GradleJavaProject rootGjp = GradleJavaProject.get(rootPrj);
+                for(GradleJavaSourceSet sourceSet : rootGjp.getSourceSets().values()) {
+                    if(sourceSet.getName().equals("main")) {
+                        runtimeFiles = sourceSet.getRuntimeClassPath();
+                    }
+                }           
+            } catch (IOException ex) { 
+                Exceptions.printStackTrace(ex);
+            } catch (IllegalArgumentException ex) {
+                Exceptions.printStackTrace(ex);
+            }
+            
+            for(File file : runtimeFiles) {
+                // logger.info(file.getName() + " : "  + file.getAbsolutePath());
+                FileObject fo = FileUtil.toFileObject(file);
+                if(fo != null && !fo.isFolder()) {
+                    logger.info(fo.toURL().toExternalForm());
+                    if (!fo.equals(getAssetFolder())) {
+                            fo.addRecursiveListener(listener);
+                            logger.log(Level.INFO, "Add classpath:{0}", fo);
+                            classPathItems.add(new ClassPathItem(fo, listener));
+                            urls.add(fo.toURL());
+                        }
+                    if (fo.toURL().toExternalForm().startsWith("jar")) {
+                            logger.log(Level.INFO, "Add Gradle locator:{0}", fo.toURL());
+                            jarItems.add(fo);
+                            registerLocator(fo.toURL().toExternalForm(),
+                                    "com.jme3.asset.plugins.UrlLocator");
+                        }
+                }
+                
+                
+            }
+            
             loader = new URLClassLoader(urls.toArray(new URL[urls.size()]), getClass().getClassLoader());
             addClassLoader(loader);
-            logger.log(Level.FINE, "Updated {0} classpath entries and {1} url locators for project {2}", new Object[]{classPathItems.size(), jarItems.size(), project.toString()});
+            logger.log(Level.INFO, "Updated {0} classpath entries and {1} url locators for project {2}", new Object[]{classPathItems.size(), jarItems.size(), project.toString()});
         }
     }
     FileChangeListener listener = new FileChangeListener() {
@@ -225,7 +271,7 @@ public class ProjectAssetManager extends DesktopAssetManager {
         }
     };
 
-    private void updateClassLoader() {
+    public void updateClassLoader() {
         ProjectManager.mutex().postWriteRequest(new Runnable() {
             public void run() {
                 synchronized (classPathItems) {
@@ -478,16 +524,19 @@ public class ProjectAssetManager extends DesktopAssetManager {
             while (classPathItemsIter.hasNext()) {
                 ClassPathItem classPathItem = classPathItemsIter.next();
                 FileObject jarFile = classPathItem.object;
-
-                Enumeration<FileObject> jarEntry = (Enumeration<FileObject>) jarFile.getChildren(true);
-                while (jarEntry.hasMoreElements()) {
-                    FileObject jarEntryAsset = jarEntry.nextElement();
-                    if (jarEntryAsset.getExt().equalsIgnoreCase(suffix)) {
-                        if (!jarEntryAsset.getPath().startsWith("/")) {
-                            list.add(jarEntryAsset.getPath());
+                if(FileUtil.isArchiveFile(jarFile)) {
+                    FileObject jarFileRoot = FileUtil.getArchiveRoot(jarFile);
+                    Enumeration<FileObject> jarEntry = (Enumeration<FileObject>) jarFileRoot.getChildren(true);
+                    while (jarEntry.hasMoreElements()) {
+                        FileObject jarEntryAsset = jarEntry.nextElement();
+                        if (jarEntryAsset.getExt().equalsIgnoreCase(suffix)) {
+                            if (!jarEntryAsset.getPath().startsWith("/")) {
+                                list.add(jarEntryAsset.getPath());
+                            }
                         }
                     }
                 }
+                
             }
             return list;
         }
@@ -502,7 +551,14 @@ public class ProjectAssetManager extends DesktopAssetManager {
                 ClassPathItem classPathItem = classPathItemsIter.next();
                 FileObject jarFile = classPathItem.object;
 
-                Enumeration<FileObject> jarEntry = (Enumeration<FileObject>) jarFile.getChildren(true);
+                Enumeration<FileObject> jarEntry;
+                if (FileUtil.isArchiveFile(jarFile)) {
+                    FileObject jarFileRoot = FileUtil.getArchiveRoot(jarFile);
+                    jarEntry = (Enumeration<FileObject>) jarFileRoot.getChildren(true);
+                } else {
+                    jarEntry = (Enumeration<FileObject>) jarFile.getChildren(true);
+                }
+
                 while (jarEntry.hasMoreElements()) {
                     FileObject jarEntryAsset = jarEntry.nextElement();
                     if (jarEntryAsset.getPath().equalsIgnoreCase(name)) {

--- a/jme3-core/src/com/jme3/gde/core/assets/ProjectAssetManager.java
+++ b/jme3-core/src/com/jme3/gde/core/assets/ProjectAssetManager.java
@@ -210,12 +210,12 @@ public class ProjectAssetManager extends DesktopAssetManager {
                     logger.info(fo.toURL().toExternalForm());
                     if (!fo.equals(getAssetFolder())) {
                             fo.addRecursiveListener(listener);
-                            logger.log(Level.INFO, "Add classpath:{0}", fo);
+                            logger.log(Level.FINE, "Add classpath:{0}", fo);
                             classPathItems.add(new ClassPathItem(fo, listener));
                             urls.add(fo.toURL());
                         }
                     if (fo.toURL().toExternalForm().startsWith("jar")) {
-                            logger.log(Level.INFO, "Add Gradle locator:{0}", fo.toURL());
+                            logger.log(Level.FINE, "Add Gradle locator:{0}", fo.toURL());
                             jarItems.add(fo);
                             registerLocator(fo.toURL().toExternalForm(),
                                     "com.jme3.asset.plugins.UrlLocator");
@@ -227,7 +227,7 @@ public class ProjectAssetManager extends DesktopAssetManager {
             
             loader = new URLClassLoader(urls.toArray(new URL[urls.size()]), getClass().getClassLoader());
             addClassLoader(loader);
-            logger.log(Level.INFO, "Updated {0} classpath entries and {1} url locators for project {2}", new Object[]{classPathItems.size(), jarItems.size(), project.toString()});
+            logger.log(Level.FINE, "Updated {0} classpath entries and {1} url locators for project {2}", new Object[]{classPathItems.size(), jarItems.size(), project.toString()});
         }
     }
     FileChangeListener listener = new FileChangeListener() {
@@ -524,19 +524,22 @@ public class ProjectAssetManager extends DesktopAssetManager {
             while (classPathItemsIter.hasNext()) {
                 ClassPathItem classPathItem = classPathItemsIter.next();
                 FileObject jarFile = classPathItem.object;
-                if(FileUtil.isArchiveFile(jarFile)) {
-                    FileObject jarFileRoot = FileUtil.getArchiveRoot(jarFile);
-                    Enumeration<FileObject> jarEntry = (Enumeration<FileObject>) jarFileRoot.getChildren(true);
-                    while (jarEntry.hasMoreElements()) {
-                        FileObject jarEntryAsset = jarEntry.nextElement();
-                        if (jarEntryAsset.getExt().equalsIgnoreCase(suffix)) {
-                            if (!jarEntryAsset.getPath().startsWith("/")) {
-                                list.add(jarEntryAsset.getPath());
-                            }
+                
+                // Gradle projects don't know that the dependency is a Jar file
+                if (FileUtil.isArchiveFile(jarFile)) {
+                    jarFile = FileUtil.getArchiveRoot(jarFile);
+                }
+
+                Enumeration<FileObject> jarEntry = (Enumeration<FileObject>) jarFile.getChildren(true);
+                while (jarEntry.hasMoreElements()) {
+                    FileObject jarEntryAsset = jarEntry.nextElement();
+                    if (jarEntryAsset.getExt().equalsIgnoreCase(suffix)) {
+                        if (!jarEntryAsset.getPath().startsWith("/")) {
+                            list.add(jarEntryAsset.getPath());
                         }
                     }
                 }
-                
+
             }
             return list;
         }

--- a/jme3-core/src/com/jme3/gde/core/assets/actions/UpdateProjectAssetManagerAfterBuild.java
+++ b/jme3-core/src/com/jme3/gde/core/assets/actions/UpdateProjectAssetManagerAfterBuild.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2009-2023 jMonkeyEngine
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ * * Redistributions of source code must retain the above copyright
+ *   notice, this list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright
+ *   notice, this list of conditions and the following disclaimer in the
+ *   documentation and/or other materials provided with the distribution.
+ *
+ * * Neither the name of 'jMonkeyEngine' nor the names of its contributors
+ *   may be used to endorse or promote products derived from this software
+ *   without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+ * TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.jme3.gde.core.assets.actions;
+
+import com.jme3.gde.core.assets.ProjectAssetManager;
+import java.io.PrintWriter;
+import org.netbeans.api.project.Project;
+import org.netbeans.modules.gradle.api.NbGradleProject;
+import org.netbeans.modules.gradle.spi.actions.AfterBuildActionHook;
+import org.netbeans.spi.project.ProjectServiceProvider;
+import org.openide.util.Lookup;
+
+/**
+ * Hook that fires after a Gradle JME project has been build and requests
+ * the ProjectAssetManager to update its ClassLoader (e.g. in case new
+ * dependencies have been added)
+ * 
+ * @author peedeeboy
+ */
+@ProjectServiceProvider(service = AfterBuildActionHook.class, projectType = NbGradleProject.GRADLE_PROJECT_TYPE)
+public class UpdateProjectAssetManagerAfterBuild implements AfterBuildActionHook {
+
+    final Project project;
+
+    public UpdateProjectAssetManagerAfterBuild(Project project) {
+        this.project = project;
+    }
+    
+    @Override
+    public void afterAction(String string, Lookup lkp, int i, PrintWriter writer) {
+        ProjectAssetManager projectAssetManager = project
+                .getLookup()
+                .lookup(ProjectAssetManager.class);
+        if (projectAssetManager != null) {
+            projectAssetManager.updateClassLoader();
+        }
+    }
+    
+}

--- a/jme3-core/src/com/jme3/gde/core/assets/actions/UpdateProjectAssetManagerAfterBuild.java
+++ b/jme3-core/src/com/jme3/gde/core/assets/actions/UpdateProjectAssetManagerAfterBuild.java
@@ -40,7 +40,7 @@ import org.netbeans.spi.project.ProjectServiceProvider;
 import org.openide.util.Lookup;
 
 /**
- * Hook that fires after a Gradle JME project has been build and requests
+ * Hook that fires after a Gradle JME project has been built and requests
  * the ProjectAssetManager to update its ClassLoader (e.g. in case new
  * dependencies have been added)
  * 


### PR DESCRIPTION
Hopefully goes some way to fixing #373 

A couple of bits that could use further refinement:

1. When you first create a new Gradle JME project, NB will prompt you for a priming build - due to changes in NB's Gradle API in latest version, because our Gradle project is created by unziping a file rather than using NB's Gradle API, it is untrusted at this stage and the priming build doesn't run.  This means the user need to run Gradle build again manually before resources will be loaded off the Gradle dependencies - the real fix for this needs to be in the Gradle template.

2. Hard coded to use look at the `main` sourceset - if user has defined custom sourcesets in their `build.gradle` these will get ignored

Could do with some testing, inc. making sure nothing in Ant based projects is now broken...