### PR TITLE
Set FlatLaf Dark as default Look and Feel

### DIFF
--- a/jme3-dark-laf/nbproject/project.xml
+++ b/jme3-dark-laf/nbproject/project.xml
@@ -16,6 +16,12 @@
                     </run-dependency>
                 </dependency>
                 <dependency>
+                    <code-name-base>org.netbeans.swing.laf.flatlaf</code-name-base>
+                    <run-dependency>
+                        <specification-version>1.11</specification-version>
+                    </run-dependency>
+                </dependency>
+                <dependency>
                     <code-name-base>org.netbeans.swing.plaf</code-name-base>
                     <build-prerequisite/>
                     <compile-dependency/>

--- a/jme3-dark-laf/src/org/jme3/netbeans/plaf/darkmonkey/Installer.java
+++ b/jme3-dark-laf/src/org/jme3/netbeans/plaf/darkmonkey/Installer.java
@@ -14,12 +14,13 @@ public class Installer extends ModuleInstall {
 
     @Override
     public void restored() {
+        DarkMonkeyLookAndFeel darkMonkeyLaf = new DarkMonkeyLookAndFeel();
         UIManager.installLookAndFeel(new UIManager.LookAndFeelInfo(
-                new DarkMonkeyLookAndFeel().getName(),
+                darkMonkeyLaf.getName(),
                 DarkMonkeyLookAndFeel.class.getName()));
-        // TODO
-        
-        String[] fontsToLoad = { 
+        UIManager.put("Nb.DarkMonkeyLFCustoms", new DarkMonkeyLFCustoms(darkMonkeyLaf));
+
+        String[] fontsToLoad = {
             "fonts/DejaVuSans.ttf",
             "fonts/DejaVuSans-Bold.ttf",
             "fonts/DejaVuSans-Oblique.ttf",
@@ -34,32 +35,19 @@ public class Installer extends ModuleInstall {
             "fonts/DejaVuSansMono-BoldOblique.ttf"
         };
         DMUtils.loadFontsFromJar(this, fontsToLoad);
-    }
-    
-    static {
-        // Set DarkMonkey as the default LaF (Note: This code could also be placed inside the DarkMonkey LaF, so it'll be executed )
-        try {
-            if (NbPreferences.root().nodeExists("laf")) {
-                String LaF = NbPreferences.root().node("laf").get("laf", null);
-                if (LaF == null) { /* Did the user already set a LaF? */
-                   NbPreferences.root().node("laf").put("laf", "org.jme3.netbeans.plaf.darkmonkey.DarkMonkeyLookAndFeel"); // Set DarkMonkey as default LaF
-                    // TODO: Make this more generic and code independant. Read some other properties file
-                    
-                    /* The laf file is parsed before this code is executed so we set the LaF once programatically */
-                   UIManager.setLookAndFeel("org.jme3.netbeans.plaf.darkmonkey.DarkMonkeyLookAndFeel");
-                   
-                   /* Calling Netbeans Internal API, unfortunately there is no way around that, apart from manually fiddling with the config/.nbattrs file,
-                   which would need some parsing and a restart to take effect: <fileobject name=""> <attr name="Editors\currentFontColorProfile" stringvalue="Dark Monkey"/></fileobject>
-                   Also see http://www.netbeans.org/dtds/attributes-1_0.dtd
-                   */
-                   EditorSettings setting = org.netbeans.modules.editor.settings.storage.api.EditorSettings.getDefault();
-                   setting.setCurrentFontColorProfile("Dark Monkey");
-                }
-            }
-            
-            UIManager.put("Nb.DarkMonkeyLFCustoms", new DarkMonkeyLFCustoms((DarkMonkeyLookAndFeel)UIManager.getLookAndFeel()));
-        } catch (Exception e) {}
         
+        EditorSettings setting = org.netbeans.modules.editor.settings.storage.api.EditorSettings.getDefault();
+        setting.setCurrentFontColorProfile("Dark Monkey");
+    }
+
+    @Override
+    public void validate() throws IllegalStateException {
+
+        String LaF = NbPreferences.root().node("laf").get("laf", null);
+        if (LaF == null) {
+            /* Did the user already set a LaF? */
+            NbPreferences.root().node("laf").put("laf", "com.formdev.flatlaf.FlatDarkLaf"); // Set Flatlaf Dark as default LaF
+        }
     }
 
 }

--- a/jme3-welcome-screen/src/com/jme3/gde/welcome/GradPanel.java
+++ b/jme3-welcome-screen/src/com/jme3/gde/welcome/GradPanel.java
@@ -5,6 +5,7 @@ import java.awt.GradientPaint;
 import java.awt.Graphics;
 import java.awt.Graphics2D;
 import javax.swing.JPanel;
+import javax.swing.UIManager;
 
 /**
  *
@@ -18,10 +19,18 @@ public class GradPanel extends JPanel {
         int w = getWidth();
         int h = getHeight();
         Graphics2D g2d = (Graphics2D) grphcs;
-        GradientPaint gp = new GradientPaint(
-                0, 0, Color.WHITE,
-                0, h, Color.LIGHT_GRAY);
-
+        
+        GradientPaint gp;
+        if (UIManager.getBoolean("nb.dark.theme")) {
+            gp = new GradientPaint(
+                    0, 0, Color.DARK_GRAY,
+                    0, h, Color.GRAY);
+        } else {
+            gp = new GradientPaint(
+                    0, 0, Color.WHITE,
+                    0, h, Color.LIGHT_GRAY);
+        }
+       
         g2d.setPaint(gp);
         g2d.fillRect(0, 0, w, h);
     }


### PR DESCRIPTION
DarkMonkey has quite a few visual bugs / inconsistencies in modern Netbeans.  This is a proposal to set FlatLaf dark as the default Look and Feel, but keep the DarkMonkey editor colours.  DarkMonkey is still installed, so available to anyone who wants to switch back to it.

The gradient for the Welcome screen is updated, so if a Dark theme is detected, it will be more fitting / readable.

## Screenshots
### Welcome screen
![flatlaf_welcome](https://user-images.githubusercontent.com/44434629/210908163-ef5ed94d-94e5-4e57-8198-0358093508f6.JPG)

### Editor
![flatlaf_editor](https://user-images.githubusercontent.com/44434629/210908185-8c6e637b-917a-41cc-acc5-aad335543405.JPG)

