### PR TITLE
Update some stephengold libraries and make mavenCentral the first place

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -14,11 +14,11 @@ if (!hasProperty('mainClass')) {
 }
 
 repositories {
+	mavenCentral()
     maven { url "https://jitpack.io" }
     maven {
         url "https://maven.google.com/"
     }
-    mavenCentral()
 }
 
 configurations {
@@ -43,7 +43,7 @@ dependencies {
     corelibs dep("org.jmonkeyengine:jme3-lwjgl:$jmeVersion-$jmeVersionTag", true, true)
     corelibs dep("org.jmonkeyengine:jme3-effects:$jmeVersion-$jmeVersionTag", true, true)
     corelibs dep("org.jmonkeyengine:jme3-blender:3.3.2-stable", false, false) // Pin Pointed until jme3-blender has a dedicated release or support is phased out.
-    optlibs dep("com.github.stephengold:Minie:6.0.0", false, false) // replacement for bullet-native
+    optlibs dep("com.github.stephengold:Minie:7.1.0", false, false) // replacement for bullet-native
     corelibs dep(fileTree("lib"), false, false)
     corelibs dep("org.jmonkeyengine:jme3-jogg:$jmeVersion-$jmeVersionTag", true, true)
 
@@ -57,7 +57,7 @@ dependencies {
     optlibs dep("org.jmonkeyengine:jme3-ios:$jmeVersion-$jmeVersionTag", true, true)
     optlibs dep("org.jmonkeyengine:jme3-android-native:$jmeVersion-$jmeVersionTag", true, true)
     optlibs dep("org.jmonkeyengine:jme3-lwjgl3:$jmeVersion-$jmeVersionTag", true, true)
-    optlibs dep("com.github.stephengold:Heart:8.1.0", true, true)
+    optlibs dep("com.github.stephengold:Heart:8.2.0", true, true)
     optlibs dep("com.github.stephengold:Wes:0.7.2", true, true)
     testdatalibs dep("org.jmonkeyengine:jme3-testdata:$jmeVersion-$jmeVersionTag", false, false)
     examplelibs dep("org.jmonkeyengine:jme3-examples:$jmeVersion-$jmeVersionTag", false, true)


### PR DESCRIPTION
At least I get a build error if I don't switch the mavenCentral as first repo. com.github.stephengold:j-ogg-all is nowadays hosted in Maven central. And removed from other sources. There is simply a message to use Maven central. This fixes it for me.

```

Full Version: 3.5-2321 |  
-- | --


<span class="ConsoleLogItem__text ConsoleLogItem__text--gradle_failure">BUILD FAILED</span><span class="ConsoleLogItem__text ConsoleLogItem__text--normal"> in 6s</span><!--EndFragment-->
</body>
</html>Full Version: 3.5-2321	
POM Version: 3.5.2-SNAPSHOT	
NBM Revision: 2321	
NBM UC Suffix: nightly/3.5/plugins	
	
FAILURE: Build failed with an exception.	
	
* Where:	
Build file 'C:\Users\Toni\Documents\ToniArts\sdk\build.gradle' line: 133	
	
* What went wrong:	
A problem occurred evaluating root project 'sdk'.	
> Could not resolve all files for configuration ':corelibs'.	
   > Could not find j-ogg-all-1.0.1.jar (com.github.stephengold:j-ogg-all:1.0.1).	
     Searched in the following locations:	
         https://jitpack.io/com/github/stephengold/j-ogg-all/1.0.1/j-ogg-all-1.0.1.jar	
	
* Try:	
> Run with --stacktrace option to get the stack trace.	
> Run with --info or --debug option to get more log output.	
	
* Get more help at https://help.gradle.org/	
	
BUILD FAILED in 6s
```