### PR TITLE
Do not overwrite Editor Profile on every load

### DIFF
--- a/jme3-dark-laf/src/org/jme3/netbeans/plaf/darkmonkey/Installer.java
+++ b/jme3-dark-laf/src/org/jme3/netbeans/plaf/darkmonkey/Installer.java
@@ -12,6 +12,8 @@ import org.openide.util.NbPreferences;
 
 public class Installer extends ModuleInstall {
 
+    private static boolean isFirstInstallation = false;
+    
     @Override
     public void restored() {
         DarkMonkeyLookAndFeel darkMonkeyLaf = new DarkMonkeyLookAndFeel();
@@ -36,8 +38,10 @@ public class Installer extends ModuleInstall {
         };
         DMUtils.loadFontsFromJar(this, fontsToLoad);
         
-        EditorSettings setting = org.netbeans.modules.editor.settings.storage.api.EditorSettings.getDefault();
-        setting.setCurrentFontColorProfile("Dark Monkey");
+        if(isFirstInstallation) {
+            EditorSettings setting = org.netbeans.modules.editor.settings.storage.api.EditorSettings.getDefault();
+            setting.setCurrentFontColorProfile("Dark Monkey");
+        }
     }
 
     @Override
@@ -47,6 +51,7 @@ public class Installer extends ModuleInstall {
         if (LaF == null) {
             /* Did the user already set a LaF? */
             NbPreferences.root().node("laf").put("laf", "com.formdev.flatlaf.FlatDarkLaf"); // Set Flatlaf Dark as default LaF
+            isFirstInstallation = true;
         }
     }
 


### PR DESCRIPTION
Fixes #457 

In order to get FlatLaf Dark to work "first time" without needing an IDE reset to fix the colours of the Option header bar etc. I had to move setting the default LaF from the static initialisation block to the `validate()` lifecycle hook.

Setting the Editor profile doesn't work in the `validate()` block though (too early in IDE startup), so I moved it to the `restored()` lifecycle hook which gets called later - completely missing that it was no longer behind an `if` so Editor profile was getting set to Dark Monkey colours every time the IDE started.

This fixes that by setting a static boolean so that we only set the Editor profile if we are also setting the default LaF (i.e. the first time we load the darkmonkey module).