### PR TITLE
Fix #463 by allowing other texture settings and only changing Flip an…

### DIFF
--- a/jme3-materialeditor/src/com/jme3/gde/materials/multiview/widgets/TexturePanel.java
+++ b/jme3-materialeditor/src/com/jme3/gde/materials/multiview/widgets/TexturePanel.java
@@ -54,7 +54,8 @@ public class TexturePanel extends MaterialPropertyWidget {
                         if (texPreview == null) {
                             texPreview = new TexturePreview(manager);
                         }
-                        texPreview.requestPreview(stripQuotes(textureName), "", 80, 25, texturePreview, null);
+                        final String[] textureNameComponents = textureName.split(" ");
+                        texPreview.requestPreview(stripQuotes(textureNameComponents[textureNameComponents.length-1]), "", 80, 25, texturePreview, null);
                     } catch (AssetNotFoundException a) {
                         Logger.getLogger(MaterialEditorTopComponent.class.getName()).log(Level.WARNING, "Could not load texture {0}", textureName);
                     }
@@ -68,19 +69,21 @@ public class TexturePanel extends MaterialPropertyWidget {
     }
 
     private void updateFlipRepeat() {
-        if (flip && repeat) {
-            property.setValue("Flip Repeat " + textureName);
-            texturePreview.setToolTipText("Flip Repeat " + textureName);
-        } else if (flip) {
-            property.setValue("Flip " + textureName);
-            texturePreview.setToolTipText("Flip " + textureName);
-        } else if (repeat) {
-            property.setValue("Repeat " + textureName);
-            texturePreview.setToolTipText("Repeat " + textureName);
-        } else {
-            property.setValue(textureName);
-            texturePreview.setToolTipText(textureName);
+        String propertyValue = property.getValue();
+        propertyValue = propertyValue.replaceFirst(textureName, "");
+        if(flip && !propertyValue.contains("Flip ")) {
+            propertyValue += "Flip ";
+        } else if(!flip) {
+            propertyValue = propertyValue.replaceFirst("Flip ", "");
         }
+        if(repeat && !propertyValue.contains("Repeat ")) {
+            propertyValue += "Repeat ";
+        } else if(!repeat) {
+            propertyValue = propertyValue.replaceFirst("Repeat ", "");
+        }
+        propertyValue += textureName;
+        property.setValue(propertyValue);
+        texturePreview.setToolTipText(propertyValue);
     }
 
     private static BufferedImage resizeImage(BufferedImage originalImage) {
@@ -281,19 +284,16 @@ public class TexturePanel extends MaterialPropertyWidget {
 
             @Override
             public void run() {
-                if (property.getValue().startsWith("Flip Repeat ")) {
+                textureName = property.getValue();
+                if (textureName.contains("Flip ")) {
                     flip = true;
+                    textureName = textureName.replaceFirst("Flip ", "").trim();
+                } 
+                if (textureName.contains("Repeat ")) {
                     repeat = true;
-                    textureName = property.getValue().replaceFirst("Flip Repeat ", "").trim();
-                } else if (property.getValue().startsWith("Flip ")) {
-                    flip = true;
-                    textureName = property.getValue().replaceFirst("Flip ", "").trim();
-                } else if (property.getValue().startsWith("Repeat ")) {
-                    repeat = true;
-                    textureName = property.getValue().replaceFirst("Repeat ", "").trim();
-                } else {
-                    textureName = property.getValue();
+                    textureName = textureName.replaceFirst("Repeat ", "").trim();
                 }
+                property.setValue(textureName);
                 jLabel1.setText(property.getName());
                 jLabel1.setToolTipText(property.getName());
                 displayPreview();

--- a/jme3-materialeditor/src/com/jme3/gde/materials/multiview/widgets/TexturePanel.java
+++ b/jme3-materialeditor/src/com/jme3/gde/materials/multiview/widgets/TexturePanel.java
@@ -71,14 +71,14 @@ public class TexturePanel extends MaterialPropertyWidget {
     private void updateFlipRepeat() {
         String propertyValue = property.getValue();
         propertyValue = propertyValue.replaceFirst(textureName, "");
-        if(flip && !propertyValue.contains("Flip ")) {
+        if (flip && !propertyValue.contains("Flip ")) {
             propertyValue += "Flip ";
-        } else if(!flip) {
+        } else if (!flip) {
             propertyValue = propertyValue.replaceFirst("Flip ", "");
         }
-        if(repeat && !propertyValue.contains("Repeat ")) {
+        if (repeat && !propertyValue.contains("Repeat ")) {
             propertyValue += "Repeat ";
-        } else if(!repeat) {
+        } else if (!repeat) {
             propertyValue = propertyValue.replaceFirst("Repeat ", "");
         }
         propertyValue += textureName;

--- a/jme3-materialeditor/src/com/jme3/gde/materials/multiview/widgets/TexturePanel.java
+++ b/jme3-materialeditor/src/com/jme3/gde/materials/multiview/widgets/TexturePanel.java
@@ -55,7 +55,7 @@ public class TexturePanel extends MaterialPropertyWidget {
                             texPreview = new TexturePreview(manager);
                         }
                         final String[] textureNameComponents = textureName.split(" ");
-                        texPreview.requestPreview(stripQuotes(textureNameComponents[textureNameComponents.length-1]), "", 80, 25, texturePreview, null);
+                        texPreview.requestPreview(stripQuotes(textureNameComponents[textureNameComponents.length - 1]), "", 80, 25, texturePreview, null);
                     } catch (AssetNotFoundException a) {
                         Logger.getLogger(MaterialEditorTopComponent.class.getName()).log(Level.WARNING, "Could not load texture {0}", textureName);
                     }
@@ -280,30 +280,26 @@ public class TexturePanel extends MaterialPropertyWidget {
 
     @Override
     protected void readProperty() {
-        java.awt.EventQueue.invokeLater(new Runnable() {
-
-            @Override
-            public void run() {
-                textureName = property.getValue();
-                if (textureName.contains("Flip ")) {
-                    flip = true;
-                    textureName = textureName.replaceFirst("Flip ", "").trim();
-                } 
-                if (textureName.contains("Repeat ")) {
-                    repeat = true;
-                    textureName = textureName.replaceFirst("Repeat ", "").trim();
-                }
-                property.setValue(textureName);
-                jLabel1.setText(property.getName());
-                jLabel1.setToolTipText(property.getName());
-                displayPreview();
-                texturePreview.setToolTipText(property.getValue());
-                MaterialProperty prop = property;
-                property = null;
-                jCheckBox1.setSelected(flip);
-                jCheckBox2.setSelected(repeat);
-                property = prop;
+        java.awt.EventQueue.invokeLater(() -> {
+            textureName = property.getValue();
+            if (textureName.contains("Flip ")) {
+                flip = true;
+                textureName = textureName.replaceFirst("Flip ", "").trim();
             }
+            if (textureName.contains("Repeat ")) {
+                repeat = true;
+                textureName = textureName.replaceFirst("Repeat ", "").trim();
+            }
+            property.setValue(textureName);
+            jLabel1.setText(property.getName());
+            jLabel1.setToolTipText(property.getName());
+            displayPreview();
+            texturePreview.setToolTipText(property.getValue());
+            MaterialProperty prop = property;
+            property = null;
+            jCheckBox1.setSelected(flip);
+            jCheckBox2.setSelected(repeat);
+            property = prop;
         });
     }
 

--- a/jme3-materialeditor/src/com/jme3/gde/materials/multiview/widgets/TexturePanelSquare.java
+++ b/jme3-materialeditor/src/com/jme3/gde/materials/multiview/widgets/TexturePanelSquare.java
@@ -111,7 +111,7 @@ public class TexturePanelSquare extends MaterialPropertyWidget {
                             texPreview = new TexturePreview(manager);
                         }
                         final String[] textureNameComponents = textureName.split(" ");
-                        texPreview.requestPreview(stripQuotes(textureNameComponents[textureNameComponents.length-1]), "", 80, 25, texturePreview, null);
+                        texPreview.requestPreview(stripQuotes(textureNameComponents[textureNameComponents.length - 1]), "", 80, 25, texturePreview, null);
                     } catch (AssetNotFoundException a) {
                         Logger.getLogger(MaterialEditorTopComponent.class.getName()).log(Level.WARNING, "Could not load texture {0}", textureName);
                     }
@@ -125,19 +125,21 @@ public class TexturePanelSquare extends MaterialPropertyWidget {
     }
 
     private void updateFlipRepeat() {
-        if (flip && repeat) {
-            property.setValue("Flip Repeat " + textureName);
-            texturePreview.setToolTipText("Flip Repeat " + textureName);
-        } else if (flip) {
-            property.setValue("Flip " + textureName);
-            texturePreview.setToolTipText("Flip " + textureName);
-        } else if (repeat) {
-            property.setValue("Repeat " + textureName);
-            texturePreview.setToolTipText("Repeat " + textureName);
-        } else {
-            property.setValue(textureName);
-            texturePreview.setToolTipText(textureName);
+        String propertyValue = property.getValue();
+        propertyValue = propertyValue.replaceFirst(textureName, "");
+        if(flip && !propertyValue.contains("Flip ")) {
+            propertyValue += "Flip ";
+        } else if(!flip) {
+            propertyValue = propertyValue.replaceFirst("Flip ", "");
         }
+        if(repeat && !propertyValue.contains("Repeat ")) {
+            propertyValue += "Repeat ";
+        } else if(!repeat) {
+            propertyValue = propertyValue.replaceFirst("Repeat ", "");
+        }
+        propertyValue += textureName;
+        property.setValue(propertyValue);
+        texturePreview.setToolTipText(propertyValue);
     }
 
     /** This method is called from within the constructor to
@@ -269,31 +271,24 @@ public class TexturePanelSquare extends MaterialPropertyWidget {
 
     @Override
     protected void readProperty() {
-        java.awt.EventQueue.invokeLater(new Runnable() {
-
-            @Override
-            public void run() {
-                if (property.getValue().startsWith("Flip Repeat ")) {
-                    flip = true;
-                    repeat = true;
-                    textureName = property.getValue().replaceFirst("Flip Repeat ", "").trim();
-                } else if (property.getValue().startsWith("Flip ")) {
-                    flip = true;
-                    textureName = property.getValue().replaceFirst("Flip ", "").trim();
-                } else if (property.getValue().startsWith("Repeat ")) {
-                    repeat = true;
-                    textureName = property.getValue().replaceFirst("Repeat ", "").trim();
-                } else {
-                    textureName = property.getValue();
-                }
-                displayPreview();
-                texturePreview.setToolTipText(property.getValue());
-                MaterialProperty prop = property;
-                property = null;
-                jCheckBox1.setSelected(flip);
-                jCheckBox2.setSelected(repeat);
-                property = prop;
+        java.awt.EventQueue.invokeLater(() -> {
+            textureName = property.getValue();
+            if (textureName.contains("Flip ")) {
+                flip = true;
+                textureName = textureName.replaceFirst("Flip ", "").trim();
             }
+            if (textureName.contains("Repeat ")) {
+                repeat = true;
+                textureName = textureName.replaceFirst("Repeat ", "").trim();
+            }
+            property.setValue(textureName);
+            displayPreview();
+            texturePreview.setToolTipText(property.getValue());
+            MaterialProperty prop = property;
+            property = null;
+            jCheckBox1.setSelected(flip);
+            jCheckBox2.setSelected(repeat);
+            property = prop;
         });
     }
 

--- a/jme3-materialeditor/src/com/jme3/gde/materials/multiview/widgets/TexturePanelSquare.java
+++ b/jme3-materialeditor/src/com/jme3/gde/materials/multiview/widgets/TexturePanelSquare.java
@@ -110,7 +110,8 @@ public class TexturePanelSquare extends MaterialPropertyWidget {
                         if (texPreview == null) {
                             texPreview = new TexturePreview(manager);
                         }
-                        texPreview.requestPreview(stripQuotes(textureName), "", 80, 25, texturePreview, null);
+                        final String[] textureNameComponents = textureName.split(" ");
+                        texPreview.requestPreview(stripQuotes(textureNameComponents[textureNameComponents.length-1]), "", 80, 25, texturePreview, null);
                     } catch (AssetNotFoundException a) {
                         Logger.getLogger(MaterialEditorTopComponent.class.getName()).log(Level.WARNING, "Could not load texture {0}", textureName);
                     }

--- a/jme3-materialeditor/src/com/jme3/gde/materials/multiview/widgets/TexturePanelSquare.java
+++ b/jme3-materialeditor/src/com/jme3/gde/materials/multiview/widgets/TexturePanelSquare.java
@@ -127,14 +127,14 @@ public class TexturePanelSquare extends MaterialPropertyWidget {
     private void updateFlipRepeat() {
         String propertyValue = property.getValue();
         propertyValue = propertyValue.replaceFirst(textureName, "");
-        if(flip && !propertyValue.contains("Flip ")) {
+        if (flip && !propertyValue.contains("Flip ")) {
             propertyValue += "Flip ";
-        } else if(!flip) {
+        } else if (!flip) {
             propertyValue = propertyValue.replaceFirst("Flip ", "");
         }
-        if(repeat && !propertyValue.contains("Repeat ")) {
+        if (repeat && !propertyValue.contains("Repeat ")) {
             propertyValue += "Repeat ";
-        } else if(!repeat) {
+        } else if (!repeat) {
             propertyValue = propertyValue.replaceFirst("Repeat ", "");
         }
         propertyValue += textureName;


### PR DESCRIPTION
…d Repeat

This is a preliminary fix. Not ready to merge yet.
I'd like a second set of eyes before merging.

So the cause was that all those "new" settings have never been implemented in the Material Editor.
Implementing all those is an undertaking I'm not ready to do right now. So my proposed interim solution is to not care about other settings than "Flip" and "Repeat", but not overwrite them either. This allows advanced users to keep modifying their materials in the Material Editor (but preview might be wrong? I'm not familiar with the settings).

Edit: Still need to update TexturePanelSquare. Only used in shader editor, I think