### PR TITLE
Update license years

### DIFF
--- a/license-jme.txt
+++ b/license-jme.txt
@@ -1,4 +1,4 @@
-Copyright (c) 2003-2016 jMonkeyEngine
+Copyright (c) 2003-2023 jMonkeyEngine
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/licenses-sdk.txt
+++ b/licenses-sdk.txt
@@ -1,7 +1,7 @@
 ******************************************************************************
 JME LICENSE
 ******************************************************************************
-Copyright (c) 2003-2016 jMonkeyEngine
+Copyright (c) 2003-2023 jMonkeyEngine
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without


### PR DESCRIPTION
Resolves #483 

-jme-txt is used by the installer. At least according to Netbeans properties on the project. Did not test it. Also changed the other license at the same time.