### PR TITLE
Fix Windows installer

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,7 @@ jobs:
     - name: Override Harness (custom icon)
       run: ./gradlew overrideHarness -Ptag_name=${{ github.ref_name }}
     - name: Build Installers
-      run: ant -Dstorepass="$NBM_SIGN_PASS" -Dpack200.enabled=true set-spec-version build-installers unset-spec-version
+      run: ant -Dstorepass="$NBM_SIGN_PASS" -Dpack200.enabled=false set-spec-version build-installers unset-spec-version
       env:
         BUILD_X86: true
         BUILD_X64: true

--- a/build.xml
+++ b/build.xml
@@ -272,7 +272,7 @@
             <!-- <property name="generate.installer.for.platforms" value="windows-x86 windows-x64 linux-x86 linux-x64 macosx"/> -->
             <property name="generator-jdk-location-forward-slashes" value="${java.home}"/>
             <property name="generated-installers-location-forward-slashes" value="${basedir}/build/installer"/>
-            <property name="pack200.enabled" value="true"/>
+            <property name="pack200.enabled" value="false"/>
             <property name="nbi.icon.file" value="${basedir}/jmonkeyplatform.png"/>
             <property name="nbi.dock.icon.file" value="${basedir}/jmonkeyplatform.icns"/>
             <property name="product.description" value="${app.description}"/>

--- a/jdks/download-jdks.sh
+++ b/jdks/download-jdks.sh
@@ -165,12 +165,10 @@ function unpack_windows {
     find . -exec chmod u+w {} \; # Make all file writable to allow uninstaller's cleaner to remove file    
     
     find . -type f \( -name "*.exe" -o -name "*.dll" \) -exec chmod u+rwx {} \; # Make them executable
-
-    find . -type f -name "*.pack" | while read eachFile; do
-        echo ">> Unpacking $eachFile ...";
-        unpack200 $eachFile ${eachFile%.pack}.jar;
-        rm $eachFile;
-    done
+    
+    # Insert fake unpack200.exe
+    # See https://github.com/jMonkeyEngine/sdk/issues/491
+    touch bin/unpack200.exe
     
     cd ../
 
@@ -246,13 +244,6 @@ function compile_other {
     if [ ! -f "$unzipsfxname" ]; then
         echo "No unzipsfx for platform $1-$3 found at $unzipsfxname, cannot continue"
         exit 1
-    fi
-
-    echo "> Creating SFX JDK package $name"
-    if [ -f "$1-$2/jre/lib/rt.jar" ]; then # Already packed?
-        echo "> PACK200 rt.jar"
-        pack200 -J-Xmx1024m $1-$2/jre/lib/rt.jar.pack.gz $1-$2/jre/lib/rt.jar
-        rm -rf $1-$2/jre/lib/rt.jar
     fi
 
     echo "> Zipping JDK"


### PR DESCRIPTION
pack200 was removed with Java 14. We are on Java 17. No-go. I did not test this but looks like the Windows installer falls to using the bundled JDK (17) to try unpack pack200 and fails. I have no idea why it works on Linux.