### PR TITLE
Bump Android build to Java 8

### DIFF
--- a/JME3TestsTemplateAndroid/nbproject/project.properties
+++ b/JME3TestsTemplateAndroid/nbproject/project.properties
@@ -57,8 +57,8 @@ javac.deprecation=false
 javac.external.vm=false
 javac.processorpath=\
     ${javac.classpath}
-javac.source=1.7
-javac.target=1.7
+javac.source=1.8
+javac.target=1.8
 javac.test.classpath=\
     ${javac.classpath}:\
     ${build.classes.dir}


### PR DESCRIPTION
Hmm yeah, no one is going to have Java 7 installed. Set to Java 8. I understand this is the version you want to use for Android. This just hopefully bumps the out-of-the-box compatibility forward. Although.... I'm not sure at all. I am totally out of the water here...