### PR TITLE
Add awt-dialogs to get jME settings dialog back

### DIFF
--- a/BasicGameTemplate/nbproject/project.properties
+++ b/BasicGameTemplate/nbproject/project.properties
@@ -42,7 +42,8 @@ javac.classpath=\
     ${libs.jme3-lwjgl.classpath}:\
     ${libs.jme3-effects.classpath}:\
     ${libs.jme3-terrain.classpath}:\
-    ${libs.jme3-jbullet.classpath}
+    ${libs.jme3-jbullet.classpath}:\
+    ${libs.jme3-awt-dialogs.classpath}
 # Space-separated list of extra javac options
 javac.compilerargs=
 javac.deprecation=false

--- a/JME3TestsTemplate/nbproject/project.properties
+++ b/JME3TestsTemplate/nbproject/project.properties
@@ -36,7 +36,8 @@ javac.classpath=\
     ${libs.jme3-effects.classpath}:\
     ${libs.jme3-terrain.classpath}:\
     ${libs.jme3-jbullet.classpath}:\
-    ${libs.jme3-test-data.classpath}
+    ${libs.jme3-test-data.classpath}:\
+    ${libs.jme3-awt-dialogs.classpath}
 # Space-separated list of extra javac options
 javac.compilerargs=
 javac.deprecation=false

--- a/build.gradle
+++ b/build.gradle
@@ -40,6 +40,7 @@ dependencies {
 
     corelibs dep("org.jmonkeyengine:jme3-core:$jmeVersion-$jmeVersionTag", true, true)
     corelibs dep("org.jmonkeyengine:jme3-desktop:$jmeVersion-$jmeVersionTag", true, true)
+	corelibs dep("org.jmonkeyengine:jme3-awt-dialogs:$jmeVersion-$jmeVersionTag", true, true)
     corelibs dep("org.jmonkeyengine:jme3-lwjgl:$jmeVersion-$jmeVersionTag", true, true)
     corelibs dep("org.jmonkeyengine:jme3-effects:$jmeVersion-$jmeVersionTag", true, true)
     corelibs dep("org.jmonkeyengine:jme3-blender:3.3.2-stable", false, false) // Pin Pointed until jme3-blender has a dedicated release or support is phased out.

--- a/jme3-templates/src/com/jme3/gde/templates/files/freemarker/build.gradle.ftl
+++ b/jme3-templates/src/com/jme3/gde/templates/files/freemarker/build.gradle.ftl
@@ -44,6 +44,9 @@ dependencies {
   // Core JME
   implementation "org.jmonkeyengine:jme3-core:$jmeVer"
   implementation "org.jmonkeyengine:jme3-desktop:$jmeVer"
+  <#if jmeVersion.versionInfo.major gt 3 || (jmeVersion.versionInfo.major == 3 && jmeVersion.versionInfo.minor gte 6 )>
+  implementation "org.jmonkeyengine:jme3-awt-dialogs:$jmeVer"
+  </#if>
   <#if lwjglLibrary.isCoreJmeLibrary == true>
   implementation "${lwjglLibrary.groupId}:${lwjglLibrary.artifactId}:$jmeVer"
   <#else>

--- a/jme3-templates/src/com/jme3/gde/templates/gradledesktop/GradleDesktopGameJMEVersionPanelVisual.java
+++ b/jme3-templates/src/com/jme3/gde/templates/gradledesktop/GradleDesktopGameJMEVersionPanelVisual.java
@@ -167,7 +167,7 @@ public class GradleDesktopGameJMEVersionPanelVisual extends JPanel {
     }
 
     protected void store(WizardDescriptor d) {
-        String jmeVersion = jmeVersionComboBox.getSelectedItem().toString();
+        LibraryVersion jmeVersion = jmeVersionComboBox.getItemAt(jmeVersionComboBox.getSelectedIndex());
         TemplateLibrary lwjglLibrary = lwjglComboBox.getItemAt(lwjglComboBox.getSelectedIndex());
 
         d.putProperty("jmeVersion", jmeVersion);


### PR DESCRIPTION
Resolves #460 

Gradle, Ant and the test templates, they will all have this now. Gradle template of course is version sensitive in this.