### PR TITLE
Make Scene Composer grid symmetrical

### DIFF
--- a/jme3-core/src/com/jme3/gde/core/scene/controller/SceneToolController.java
+++ b/jme3-core/src/com/jme3/gde/core/scene/controller/SceneToolController.java
@@ -136,9 +136,9 @@ public class SceneToolController extends AbstractAppState {
         //cursor.attachChild(cursorArrowZ);
 
         //grid
-        grid = new Geometry("grid", new Grid(20, 20, 1.0f));
+        grid = new Geometry("grid", new Grid(21, 21, 1.0f));
         grid.setMaterial(grayMat);
-        grid.setLocalTranslation(-10, 0, -10);
+        grid.center().move(Vector3f.ZERO);
         SceneApplication.getApplication().enqueue(new Callable<Object>() {
             @Override
             public Object call() throws Exception {


### PR DESCRIPTION
Changes Scene Composer grid from 20 lines x 20 lines (19 squares x 19 squares) to 21 lines x 21 lines (20 squares x 20 squares) so it is symmetrical.

Fixes #516 

**Before**:
![898f1e7ccd4c985765d289fc45f7b83b3676445c](https://github.com/jMonkeyEngine/sdk/assets/44434629/c35ecdb6-6e9d-407b-99c2-7946d5af8370)

**After**:
![image](https://github.com/jMonkeyEngine/sdk/assets/44434629/16828407-7b30-4e3b-ba1e-4d2f3004ac90)
