### PR TITLE
Disable Windows x86 by default

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,7 @@ jobs:
     - name: Build Installers
       run: ant -Dstorepass="$NBM_SIGN_PASS" -Dpack200.enabled=false set-spec-version build-installers unset-spec-version
       env:
-        BUILD_X86: true
+        BUILD_X86: false
         BUILD_X64: true
         BUILD_OTHER: true
     - name: Fix Platform Independent Build

--- a/build.xml
+++ b/build.xml
@@ -220,7 +220,7 @@
             </and>
             <then>
                 <echo message="No platform specified, building all platforms"/>
-                <property name="generate.installer.for.platforms" value="windows-x86 windows-x64 linux-x64 macosx"/>
+                <property name="generate.installer.for.platforms" value="windows-x64 linux-x64 macosx"/>
             </then>
             <else>
                 <if>

--- a/jdks/download-jdks.sh
+++ b/jdks/download-jdks.sh
@@ -263,14 +263,14 @@ else
     then
         build_mac_jdk &
         build_other_jdk linux x64 x64 &
-        build_other_jdk windows x86-32 x86 &
+        # Windows 32bit not by default build_other_jdk windows x86-32 x86 &
         build_other_jdk windows x64 x64 &
     else
         build_mac_jdk
         build_other_jdk linux x64 x64
-        build_other_jdk windows x86-32 x86
+        ## Windows 32bit not by default build_other_jdk windows x86-32 x86
         build_other_jdk windows x64 x64
-        #Linux 32bit not supported... build_other_jdk linux x86-32
+        # Linux 32bit not supported... build_other_jdk linux x86-32
     fi
     
 fi


### PR DESCRIPTION
Resolves #558 

Not build by default and not build by our release build. Downloading the JDKs doesn't get the parameters what to build, so enabling x86 build doesn't work anymore straight as corresponding JDK is missing. I think it is better this way, much lighter for everyone. x86 isn't coming back really...