### PR TITLE
Issue 561

### DIFF
--- a/jme3-materialeditor/src/com/jme3/gde/materials/multiview/widgets/TexturePanel.java
+++ b/jme3-materialeditor/src/com/jme3/gde/materials/multiview/widgets/TexturePanel.java
@@ -83,17 +83,17 @@ public class TexturePanel extends MaterialPropertyWidget implements TextureDropT
     // visible for tests
     protected String extractTextureName(final String property) {
         final String[] textureNameComponents = property.split("\"");
-        if(property.endsWith("\"")) {
-            // texture name is last in property
-            return textureNameComponents[textureNameComponents.length - 1];
+        final int length = textureNameComponents.length;
+        if(property.endsWith("\"") || length == 1) {
+            // texture name is last in property, or it's empty
+            return textureNameComponents[length - 1].trim();
         }
         // has extra properties after name, return segment second to last
-        return textureNameComponents[textureNameComponents.length - 2];
+        return textureNameComponents[length - 2].trim();
     }
 
     // visible for tests
     protected void updateFlipRepeat() {
-        String propertyValue = "";
         final List<String> segments = new ArrayList<>();
         if (flip) {
             segments.add(FLIP);
@@ -285,7 +285,7 @@ public class TexturePanel extends MaterialPropertyWidget implements TextureDropT
     @Override
     protected void readProperty() {
         java.awt.EventQueue.invokeLater(() -> {
-            String prop = property.getValue();
+            String prop = property.getValue().trim();
             if (prop.contains(FLIP)) {
                 flip = true;
                 prop = prop.replace(FLIP, EMPTY).trim();
@@ -334,8 +334,9 @@ public class TexturePanel extends MaterialPropertyWidget implements TextureDropT
                 textureName = "\"" + name + "\"";
             }
             property.setValue(textureName);
-            displayPreview();
+            
             updateFlipRepeat();
+            displayPreview();
             java.awt.EventQueue.invokeLater(() -> {
                 fireChanged();
             });

--- a/jme3-materialeditor/src/com/jme3/gde/materials/multiview/widgets/TexturePanel.java
+++ b/jme3-materialeditor/src/com/jme3/gde/materials/multiview/widgets/TexturePanel.java
@@ -14,15 +14,14 @@ import com.jme3.asset.AssetNotFoundException;
 import com.jme3.gde.core.assets.ProjectAssetManager;
 import com.jme3.gde.core.properties.TexturePropertyEditor;
 import com.jme3.gde.core.properties.preview.TexturePreview;
-import com.jme3.gde.materials.MaterialProperty;
 import com.jme3.gde.materials.dnd.TextureDropTargetListener;
 import com.jme3.gde.materials.dnd.TextureDropTargetListener.TextureDropTarget;
 import com.jme3.gde.materials.multiview.MaterialEditorTopComponent;
 import com.jme3.gde.materials.multiview.widgets.icons.Icons;
 import java.awt.Component;
-import java.awt.Graphics2D;
 import java.awt.dnd.DropTarget;
-import java.awt.image.BufferedImage;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -35,11 +34,16 @@ import java.util.logging.Logger;
  */
 public class TexturePanel extends MaterialPropertyWidget implements TextureDropTarget{
 
+    private final String REPEAT = "Repeat";
+    private final String FLIP = "Flip";
+    private final String EMPTY = "";
+    
     private TexturePropertyEditor editor;
     private ProjectAssetManager manager;
     private boolean flip = false;
     private boolean repeat = false;
     protected String textureName = null; // always enclosed with ""
+    protected String extraProperties = ""; // in case the source file has extra properties on texture
     private TexturePreview texPreview;
     private final ScheduledThreadPoolExecutor exec = new ScheduledThreadPoolExecutor(1);
 
@@ -47,7 +51,7 @@ public class TexturePanel extends MaterialPropertyWidget implements TextureDropT
      * Used by tests
      */
     protected TexturePanel() {
-        
+        initComponents();
     }
     
     /**
@@ -60,66 +64,47 @@ public class TexturePanel extends MaterialPropertyWidget implements TextureDropT
         
         setDropTarget(new DropTarget(this, new TextureDropTargetListener(this)));
     }
-
+    
     private void displayPreview() {
-        if (!"".equals(textureName)) {
-            exec.execute(new Runnable() {
-                @Override
-                public void run() {
-                    try {
-                        if (texPreview == null) {
-                            texPreview = new TexturePreview(manager);
-                        }
-                        texPreview.requestPreview(extractTextureName(textureName), "", 80, 25, texturePreview, null);
-                    } catch (AssetNotFoundException a) {
-                        Logger.getLogger(MaterialEditorTopComponent.class.getName()).log(Level.WARNING, "Could not load texture {0}", textureName);
+        if (!EMPTY.equals(textureName)) {
+            exec.execute(() -> {
+                try {
+                    if (texPreview == null) {
+                        texPreview = new TexturePreview(manager);
                     }
+                    texPreview.requestPreview(extractTextureName(textureName), "", 80, 25, texturePreview, null);
+                } catch (AssetNotFoundException a) {
+                    Logger.getLogger(MaterialEditorTopComponent.class.getName()).log(Level.WARNING, "Could not load texture {0}", textureName);
                 }
             });
         }
     }
 
     // visible for tests
-    protected String extractTextureName(String textureName) {
-        final String[] textureNameComponents = textureName.split("\"");
-        return textureNameComponents[textureNameComponents.length - 1];
+    protected String extractTextureName(final String property) {
+        final String[] textureNameComponents = property.split("\"");
+        if(property.endsWith("\"")) {
+            // texture name is last in property
+            return textureNameComponents[textureNameComponents.length - 1];
+        }
+        // has extra properties after name, return segment second to last
+        return textureNameComponents[textureNameComponents.length - 2];
     }
 
     // visible for tests
     protected void updateFlipRepeat() {
-        String propertyValue = property.getValue();
-        propertyValue = propertyValue.replaceFirst(textureName, "");
-        if (flip && !propertyValue.contains("Flip ")) {
-            propertyValue += "Flip ";
-        } else if (!flip) {
-            propertyValue = propertyValue.replaceFirst("Flip ", "");
+        String propertyValue = "";
+        final List<String> segments = new ArrayList<>();
+        if (flip) {
+            segments.add(FLIP);
         }
-        if (repeat && !propertyValue.contains("Repeat ")) {
-            propertyValue += "Repeat ";
-        } else if (!repeat) {
-            propertyValue = propertyValue.replaceFirst("Repeat ", "");
+        if (repeat) {
+            segments.add(REPEAT);
         }
-        propertyValue += textureName;
-        property.setValue(propertyValue);
-        texturePreview.setToolTipText(propertyValue);
-    }
-
-    private static BufferedImage resizeImage(BufferedImage originalImage) {
-        int type = originalImage.getType() == 0 ? BufferedImage.TYPE_INT_ARGB : originalImage.getType();
-        float ratio = (float) originalImage.getWidth() / (float) originalImage.getHeight();
-        int width = 80;
-        int height = 25;
-        if (ratio <= 1) {
-            height = (int) ((float) width * ratio);
-        } else {
-            width = (int) ((float) height * ratio);
-        }
-        BufferedImage resizedImage = new BufferedImage(width, height, type);
-        Graphics2D g = resizedImage.createGraphics();
-        g.drawImage(originalImage, 0, 0, width, height, null);
-        g.dispose();
-
-        return resizedImage;
+        segments.add(textureName);
+        segments.add(extraProperties);
+        property.setValue(String.join(" ", segments).trim());
+        texturePreview.setToolTipText(property.getValue());
     }
 
     /**
@@ -282,7 +267,7 @@ public class TexturePanel extends MaterialPropertyWidget implements TextureDropT
 
     private void texturePreviewMouseClicked(java.awt.event.MouseEvent evt) {//GEN-FIRST:event_texturePreviewMouseClicked
         Component view = editor.getCustomEditor();
-        property.setValue("");
+        property.setValue(EMPTY);
         view.setVisible(true);
         if (editor.getValue() != null) {
             textureName = "\"" + editor.getAsText() + "\"";
@@ -300,25 +285,25 @@ public class TexturePanel extends MaterialPropertyWidget implements TextureDropT
     @Override
     protected void readProperty() {
         java.awt.EventQueue.invokeLater(() -> {
-            textureName = property.getValue();
-            if (textureName.contains("Flip ")) {
+            String prop = property.getValue();
+            if (prop.contains(FLIP)) {
                 flip = true;
-                textureName = textureName.replaceFirst("Flip ", "").trim();
+                prop = prop.replace(FLIP, EMPTY).trim();
             }
-            if (textureName.contains("Repeat ")) {
+            if (prop.contains(REPEAT)) {
                 repeat = true;
-                textureName = textureName.replaceFirst("Repeat ", "").trim();
+                prop = prop.replace(REPEAT, EMPTY).trim();
             }
-            property.setValue(textureName);
+            textureName = "\"" + extractTextureName(prop) + "\"";
+            extraProperties = prop.replace(textureName, "").trim();
+            
+
             jLabel1.setText(property.getName());
             jLabel1.setToolTipText(property.getName());
             displayPreview();
             texturePreview.setToolTipText(property.getValue());
-            MaterialProperty prop = property;
-            property = null;
             jCheckBox1.setSelected(flip);
             jCheckBox2.setSelected(repeat);
-            property = prop;
         });
     }
 
@@ -356,5 +341,15 @@ public class TexturePanel extends MaterialPropertyWidget implements TextureDropT
             });
         });
         
+    }
+    
+    // visible for tests
+    protected boolean isFlip() {
+        return flip;
+    }
+    
+    // visible for tests
+    protected boolean isRepeat() {
+        return repeat;
     }
 }

--- a/jme3-materialeditor/test/unit/src/com/jme3/gde/materials/multiview/widgets/TexturePanelTest.java
+++ b/jme3-materialeditor/test/unit/src/com/jme3/gde/materials/multiview/widgets/TexturePanelTest.java
@@ -32,7 +32,14 @@
 package com.jme3.gde.materials.multiview.widgets;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import org.junit.jupiter.api.Test;
+import com.jme3.gde.materials.MaterialProperty;
+import java.awt.EventQueue;
+import java.lang.reflect.InvocationTargetException;
+import org.openide.util.Exceptions;
+
 
 
 /**
@@ -44,24 +51,125 @@ public class TexturePanelTest {
     public TexturePanelTest() {
     }
 
+    String textureNameWithModifier = "Flip Repeat \"simple_name.jpg\"";
+    String textureNameWithSpaces = "\"texture name with spaces.jpg\"";
+    String textureNameWithSpaceAndModifier = "Flip Repeat \"texture name with spaces.jpg\"";
+    String textureName = "\"simple_name.jpg\"";
+    String textureNameWithExtraInfo = "\"simple_name.jpg\" LINEAR";
+    
     @Test
     public void testExtractTextureName() {
         TexturePanel texturePanel = new TexturePanel();
-        String textureName = "\"simple_name.jpg\"";
+        
         String extractedName = texturePanel.extractTextureName(textureName);
         assertEquals("simple_name.jpg", extractedName);
         
-        String textureNameWithModifier = "Flip Repeat \"simple_name.jpg\"";
+        
         extractedName = texturePanel.extractTextureName(textureNameWithModifier);
         assertEquals("simple_name.jpg", extractedName);
         
-        String textureNameWithSpaces = "\"texture name with spaces.jpg\"";
+        
         extractedName = texturePanel.extractTextureName(textureNameWithSpaces);
         assertEquals("texture name with spaces.jpg", extractedName);
         
-        String textureNameWithSpaceAndModifier = "Flip Repeat \"texture name with spaces.jpg\"";
+        
         extractedName = texturePanel.extractTextureName(textureNameWithSpaceAndModifier);
         assertEquals("texture name with spaces.jpg", extractedName);
+        
+        extractedName = texturePanel.extractTextureName(textureNameWithExtraInfo);
+        assertEquals("simple_name.jpg", extractedName);
+    }
+    
+    @Test
+    public void testReadPropertyFlipRepeat() {
+        TexturePanel texturePanel = new TexturePanel();
+        texturePanel.setProperty(new MaterialProperty());
+        texturePanel.property.setValue(textureNameWithModifier);
+        try {
+            EventQueue.invokeAndWait(() -> {
+                texturePanel.readProperty();
+            });
+        } catch (InterruptedException | InvocationTargetException ex) {
+            Exceptions.printStackTrace(ex);
+        }
+        
+        
+        assertEquals(textureName, texturePanel.textureName);
+        assertTrue(texturePanel.isFlip());
+        assertTrue(texturePanel.isRepeat());
+        assertEquals(texturePanel.extraProperties, "");
+    }
+    
+    @Test
+    public void testReadProperty() {
+        TexturePanel texturePanel = new TexturePanel();
+        texturePanel.setProperty(new MaterialProperty());
+        texturePanel.property.setValue(textureName);
+        
+        try {
+            EventQueue.invokeAndWait(() -> {
+                texturePanel.readProperty();
+            });
+        } catch (InterruptedException | InvocationTargetException ex) {
+            Exceptions.printStackTrace(ex);
+        }
+        
+        assertEquals(texturePanel.textureName, textureName);
+        assertFalse(texturePanel.isFlip());
+        assertFalse(texturePanel.isRepeat());
+    }
+    
+    @Test
+    public void testReadPropertyExtraProperty() {
+        TexturePanel texturePanel = new TexturePanel();
+        texturePanel.setProperty(new MaterialProperty());
+        texturePanel.property.setValue(textureNameWithExtraInfo);
+        try {
+            EventQueue.invokeAndWait(() -> {
+                texturePanel.readProperty();
+            });
+        } catch (InterruptedException | InvocationTargetException ex) {
+            Exceptions.printStackTrace(ex);
+        }
+        
+        assertEquals(texturePanel.textureName, textureName);
+        assertEquals(texturePanel.extraProperties, "LINEAR");
+    }
+    
+    @Test
+    public void testUpdateFlipRepeat() {
+        TexturePanel texturePanel = new TexturePanel();
+        texturePanel.setProperty(new MaterialProperty());
+        
+        texturePanel.property.setValue(textureNameWithModifier);
+        try {
+            EventQueue.invokeAndWait(() -> {
+                texturePanel.readProperty();
+            });
+        } catch (InterruptedException | InvocationTargetException ex) {
+            Exceptions.printStackTrace(ex);
+        }
+        
+        texturePanel.updateFlipRepeat();
+        assertEquals(texturePanel.property.getValue(), textureNameWithModifier);
+    }
+    
+    @Test
+    public void testUpdateFlipRepeatExtraProperty() {
+        TexturePanel texturePanel = new TexturePanel();
+        texturePanel.setProperty(new MaterialProperty());
+        texturePanel.property.setValue(textureNameWithExtraInfo);
+        try {
+            EventQueue.invokeAndWait(() -> {
+                texturePanel.readProperty();
+            });
+        } catch (InterruptedException | InvocationTargetException ex) {
+            Exceptions.printStackTrace(ex);
+        }
+        
+        texturePanel.updateFlipRepeat();
+        assertTrue(texturePanel.property.getValue().contains("LINEAR"));
+        
     }
 
 }

--- a/jme3-materialeditor/test/unit/src/com/jme3/gde/materials/multiview/widgets/TexturePanelTest.java
+++ b/jme3-materialeditor/test/unit/src/com/jme3/gde/materials/multiview/widgets/TexturePanelTest.java
@@ -55,7 +55,7 @@ public class TexturePanelTest {
     String textureNameWithSpaces = "\"texture name with spaces.jpg\"";
     String textureNameWithSpaceAndModifier = "Flip Repeat \"texture name with spaces.jpg\"";
     String textureName = "\"simple_name.jpg\"";
-    String textureNameWithExtraInfo = "\"simple_name.jpg\" LINEAR";
+    String textureNameWithExtraInfo = "Flip \"simple_name.jpg\" LINEAR";
     
     @Test
     public void testExtractTextureName() {


### PR DESCRIPTION
This is a bit of a weird one.
I think it's a regression from when I fixed something related to this a while back. The issue happens when a different texture was changed because the loaded flip and repeat weren't persisted.
I was tempted to rewrite a bit how it functioned, but also wanted to consider extra texture options (iirc that is another issue further down the list).
This refactor handles that, but I'm not sure the rest of the SDK does. At least if you try to enter something manually after the texture name, there will be a warning.
Not sure whether to keep it, or not allow anything after the texture name.
Fixes #561 and I think also #562 