### PR TITLE
Always get the latest JDK version

### DIFF
--- a/jdks/download-jdks.sh
+++ b/jdks/download-jdks.sh
@@ -81,7 +81,7 @@ function unpack_windows {
         return 0
     fi
 
-    download_jdk $1 windows .zip
+    download_jdk "$1" windows .zip
 
     mkdir -p windows-$1
     unzip -qq downloads/jdk-$1_windows.zip -d windows-$1
@@ -122,7 +122,7 @@ function unpack_linux {
         return 0
     fi
 
-    download_jdk $1 linux .tar.gz
+    download_jdk "$1" linux .tar.gz
 
     mkdir -p linux-$1
     cd linux-$1

--- a/jdks/download-jdks.sh
+++ b/jdks/download-jdks.sh
@@ -202,10 +202,10 @@ function build_other_jdk {
     echo "< OK!"
 }
 
-mkdir -p local/$jdk_major_version-$jdk_version-$jdk_build_version/downloads
-mkdir -p local/$jdk_major_version-$jdk_version-$jdk_build_version/compiled
+mkdir -p local/$jdk_major_version/downloads
+mkdir -p local/$jdk_major_version/compiled
 
-cd local/$jdk_major_version-$jdk_version-$jdk_build_version
+cd local/$jdk_major_version
 
 if [ "x$TRAVIS" != "x" ]; then
     if [ "x$BUILD_X64" != "x" ]; then


### PR DESCRIPTION
Resolves #595 

Basically now all releases will get the freshest available JDK. We no longer have the exact version info in the script but I don't think that matters. Locally I just wipe out everything before running the script. And the release is always created in a new empty environment. So the exact version in paths doesn't matter.