### PR TITLE
Upgrade to jME 3.7 BETA

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,9 +1,9 @@
 # Version number used for plugins, only 3 numbers (e.g. 3.1.3)
-jmeVersion = 3.6.1
+jmeVersion = 3.7.0
 # Version used for application and settings folder, no spaces!
-jmeMainVersion = 3.6
+jmeMainVersion = 3.7
 # Version addition pre-alpha-svn, Stable, Beta
-jmeVersionTag = stable
+jmeVersionTag = beta1.2.2
 # Increment this each time jmeVersionTag changes but jmeVersion stays the same
 #jmeVersionTagID = 0
 


### PR DESCRIPTION
With this we could also do 3.7 beta release or whatever we want to call it. I don't know when jME 3.7 stable will come out, doesn't look that it'll come out anytime soon.

Looks to work ok. Just that if one wants to create a project with Gradle, we don't offer jME 3.7 as it is in BETA (only stable versions are listed). But we are dynamic and if the stable version comes out whilst we are in this BETA... we will offer it.