### PR TITLE
Gradle template to use Java 21

### DIFF
--- a/jme3-templates/src/com/jme3/gde/templates/files/freemarker/build.gradle.ftl
+++ b/jme3-templates/src/com/jme3/gde/templates/files/freemarker/build.gradle.ftl
@@ -40,7 +40,7 @@ project(":assets") {
 
     java {
         toolchain {
-            languageVersion = JavaLanguageVersion.of(17)
+            languageVersion = JavaLanguageVersion.of(21)
         }
     }
 }
@@ -114,7 +114,7 @@ jar {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(17)
+        languageVersion = JavaLanguageVersion.of(21)
     }
 }
 


### PR DESCRIPTION
Duh, we ship Java 21. The templates need to use 21 or the user has to get Java 17. Not good.