### PR TITLE
Update Stephen's library versions

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -42,8 +42,8 @@ dependencies {
     corelibs dep("org.jmonkeyengine:jme3-plugins-json:$jmeVersion-$jmeVersionTag", true, true)
     corelibs dep("org.jmonkeyengine:jme3-lwjgl:$jmeVersion-$jmeVersionTag", true, true)
     corelibs dep("org.jmonkeyengine:jme3-effects:$jmeVersion-$jmeVersionTag", true, true)
-    corelibs dep("com.github.stephengold:Minie:8.0.0", false, false) // replacement for bullet-native
-    corelibs dep("com.github.stephengold:Heart:9.0.0", true, true) // requirement for Minie
+    corelibs dep("com.github.stephengold:Minie:8.2.0", true, true) // replacement for bullet-native
+    corelibs dep("com.github.stephengold:Heart:9.1.0", true, true) // requirement for Minie
     corelibs dep(fileTree("lib"), false, false)
     corelibs dep("org.jmonkeyengine:jme3-jogg:$jmeVersion-$jmeVersionTag", true, true)
 
@@ -63,7 +63,7 @@ dependencies {
     optlibs dep("org.jmonkeyengine:jme3-ios:$jmeVersion-$jmeVersionTag", true, true)
     optlibs dep("org.jmonkeyengine:jme3-android-native:$jmeVersion-$jmeVersionTag", true, true)
     optlibs dep("org.jmonkeyengine:jme3-lwjgl3:$jmeVersion-$jmeVersionTag", true, true)
-    optlibs dep("com.github.stephengold:Wes:0.7.5", true, true)
+    optlibs dep("com.github.stephengold:Wes:0.8.1", true, true)
     testdatalibs dep("org.jmonkeyengine:jme3-testdata:$jmeVersion-$jmeVersionTag", false, false)
     examplelibs dep("org.jmonkeyengine:jme3-examples:$jmeVersion-$jmeVersionTag", false, true)
 }


### PR DESCRIPTION
I did test the jME tests with Minie and I got Javadoc & Sources too. Looks like if you want to run jME tests with Minie, there is one function to remove and RigidBodyControl needs some field accesses replaced with getters.

I don't know if there is some 3.7 compatibility issues with the old libraries but at least now there should not be.