### PR TITLE
Get version tag from GIT when parameter not given

### DIFF
--- a/version.gradle
+++ b/version.gradle
@@ -140,7 +140,7 @@ task configureVersionInfo {
         if (project.hasProperty("tag_name")) {
             jmeGitTag = project.getProperty("tag_name")
         } else {
-            jmeGitTag = grgit.tag.list().find { it.commit == head }?.name ?: "no-tag"
+            jmeGitTag = grgit.tag.list().find { it.commit == head }?.name
         }
 
         def releaseInfo = getReleaseInfo(jmeGitTag)

--- a/version.gradle
+++ b/version.gradle
@@ -39,7 +39,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'org.ajoberstar:gradle-git:1.2.0'
+        classpath 'org.ajoberstar:gradle-git:1.6.0'
     }
 }
 
@@ -140,7 +140,7 @@ task configureVersionInfo {
         if (project.hasProperty("tag_name")) {
             jmeGitTag = project.getProperty("tag_name")
         } else {
-            jmeGitTag = grgit.tag.list().find { it.commit == head }
+            jmeGitTag = grgit.tag.list().find { it.commit == head }?.name ?: "no-tag"
         }
 
         def releaseInfo = getReleaseInfo(jmeGitTag)


### PR DESCRIPTION
Ok, this is a small thing. But locally, if you just do Gradle buildSdk, it tries to get the version from GIT tags. Well, seems it hasn't worked for awhile (or just broken recently with all the Gradle upgrades?). It gives a nasty warning while building. Release build always gives the tag so no problem there.