### PR TITLE
Release build fixes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,8 +24,6 @@ jobs:
       run: ./gradlew overrideHarness -Ptag_name=${{ github.ref_name }}
     - name: Build Installers
       run: ant -Dstorepass="$NBM_SIGN_PASS" -Dpack200.enabled=false set-spec-version build-zip unset-spec-version
-    - name: Fix Platform Independent Build
-      run: ./gradlew fixPlatformIndependent -Ptag_name=${{ github.ref_name }}
     - name: Download JDKs for the installers
       run: bash download-jdks.sh
       working-directory: installers

--- a/build.gradle
+++ b/build.gradle
@@ -643,42 +643,6 @@ tasks.register('cleanSdk') {
     }
 }
 
-tasks.register('extractPlatformIndependent', Copy) {
-    from zipTree('dist/jmonkeyplatform.zip')
-    into "dist/temp/"
-
-    exclude("jmonkeyplatform/etc/jmonkeyplatform.conf")
-}
-
-tasks.register('patchPlatformIndependent', Copy) {
-    dependsOn extractPlatformIndependent
-    from zipTree('dist/jmonkeyplatform.zip')
-    into "dist/temp/"
-
-    include("jmonkeyplatform/etc/jmonkeyplatform.conf")
-
-    filter { String line ->
-        line.startsWith('jdkhome=') ? '#jdkhome="/path/to/jdk"' : line
-    }
-
-    doLast {
-        delete(file('dist/jmonkeyplatform.zip'))
-    }
-}
-
-tasks.register('fixPlatformIndependent', Zip) {
-    dependsOn patchPlatformIndependent
-    description = "We compile our installers with the bundled jdk, but the platform independent zip doesn't have the jdk. For this we need to change the jmonkeyplatform.zip after building the installers to not have a jdk bundled"
-
-    from 'dist/temp'
-    archiveFileName = 'jmonkeyplatform.zip'
-    destinationDirectory = file('dist')
-
-    doLast {
-        delete("dist/temp")
-    }
-}
-
 wrapper {
     gradleVersion = '9.2.1'
 }

--- a/installers/windows-x64/licenses-sdk.txt
+++ b/installers/windows-x64/licenses-sdk.txt
@@ -1,7 +1,7 @@
 ******************************************************************************
 JME LICENSE
 ******************************************************************************
-Copyright (c) 2003-2025 jMonkeyEngine
+Copyright (c) 2003-2026 jMonkeyEngine
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/license-jme.txt
+++ b/license-jme.txt
@@ -1,4 +1,4 @@
-Copyright (c) 2003-2025 jMonkeyEngine
+Copyright (c) 2003-2026 jMonkeyEngine
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without


### PR DESCRIPTION
The `fixPlatformIndependent` is no longer needed as the NBPackage does this for us. It also broke the Linux releases as the repackaging didn't preserve the file permissions. By default they should be preserved but somehow this was not the case. I don't know whether that is related to the Gradle update or what. Either way this shenanigans is not needed anymore.

Linux release seems to be ok now. Windows installer is not too ok still.